### PR TITLE
docs: add product vision

### DIFF
--- a/planning/VISION.md
+++ b/planning/VISION.md
@@ -1,0 +1,90 @@
+# Product Vision — Camp Fit Fur Dogs
+
+> **Status:** Active
+> **Owner:** Frank Hughes, Product Owner
+> **Last updated:** 2026-03-29
+
+---
+
+## Vision Statement
+
+For **pet parents who consider their pets as their children**,
+who **deserve more than basic babysitting when they're away**,
+Camp Fit Fur Dogs is a **pet nursery school and hotel**
+that **delivers structured enrichment, curriculum-based activities, and transparent daily progress — the same standard a parent expects from a top-notch children's nursery**.
+Unlike **traditional kennels and pet hotels that focus on minimal custodial care**,
+our facility **treats every stay as a developmental experience with certified staff, daily report cards, and live updates**.
+
+---
+
+## Customer
+
+| Attribute        | Detail |
+|------------------|--------|
+| **Who**          | A pet parent who considers their pet as their child |
+| **Context**      | Needs care for their dog during work, travel, or daily commitments |
+| **Current tool** | Traditional kennels, pet sitters, daycare facilities |
+| **Frustration**  | Existing options treat their dog as cargo to be watched — not a family member to be enriched |
+
+---
+
+## Problem
+
+- Most pet care establishments are built around **babysitting** — safe containment and basic needs — not **enrichment and well-being**
+- Pet parents have no visibility into what their dog actually experiences during a stay
+- There is no structured, progressive programming — every visit is the same regardless of the dog's needs, temperament, or development
+
+---
+
+## Value
+
+| What exists today | What Camp Fit Fur Dogs delivers |
+|-------------------|--------------------------------|
+| Custodial watch-and-feed care | Structured enrichment programs with curriculum-based activities |
+| No communication until pickup | Daily report cards and live updates throughout the stay |
+| Untrained or minimally trained handlers | Certified staff with developmental expertise |
+| Every stay is identical | Progressive programming tailored to each dog |
+| Drop-off and hope for the best | Full transparency — parents know exactly what their dog is doing |
+
+---
+
+## Success Criteria
+
+| Signal | Target | Measured by |
+|--------|--------|-------------|
+| Pet satisfaction scores | Consistently positive behavioral indicators post-stay | Staff behavioral assessments; parent-reported behavior at home |
+| Parent satisfaction scores | 4.8+ average | Post-stay surveys and reviews |
+| Repeat bookings | >75% of parents book again within 60 days | Booking system data |
+| Referrals | >30% of new clients sourced from existing parent referrals | Intake form attribution |
+| Media buzz | Organic coverage in local and pet-industry press | Mentions, features, social engagement |
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Dog boarding and day stays with structured enrichment programs
+- Curriculum-based activities led by certified staff
+- Daily report cards and live parent updates
+- Digital platform for booking, communication, and progress tracking (web)
+
+### Out of scope (for now)
+- Veterinary services
+- Grooming
+- Retail and product sales
+- Cat or exotic pet support
+- Mobile app
+- Multi-location expansion
+
+---
+
+## Epic Alignment
+
+| Epic | Vision area |
+|------|-------------|
+| Repo Foundation | Technical foundation — enables the digital platform that powers booking, report cards, and live updates |
+
+---
+
+*This document is a stable anchor, not a living backlog item.
+Revisit only when the product direction changes — not every sprint.*


### PR DESCRIPTION
## What

Adds \\planning/VISION.md\\ — the stable anchor for all epics, stories, and sprints.

### Highlights
- **Vision:** Pet nursery school modeled after a top-notch children's nursery — enrichment over babysitting
- **Customer:** Pet parents who consider their pets as their children
- **Differentiators:** Structured enrichment programs, daily report cards, live updates, certified staff, curriculum-based activities
- **Success signals:** Pet satisfaction, parent satisfaction, repeat bookings, referrals, media buzz
- **Out of scope (for now):** Vet services, grooming, retail, cats/exotics, mobile app, multi-location

Every future epic should trace back to this document.
