### PR TITLE
chore: stamp created timestamps on planning manifests

### DIFF
--- a/planning/epics/repo-foundation.yml
+++ b/planning/epics/repo-foundation.yml
@@ -4,3 +4,5 @@ epic:
   description: |
     Establish CI, templates, solution skeleton, and operational
     docs for the Camp Fit Fur Dogs repo.
+  created: "2026-03-29T19:25:12Z"
+  issue_number: 5

--- a/planning/sprints/sprint-0.yml
+++ b/planning/sprints/sprint-0.yml
@@ -3,8 +3,9 @@ sprint:
   title: "Sprint 0 — Repo Foundation"
   start: 2026-03-30
   end: 2026-04-03
-  board: 14  # project number from create-board.sh — update after running it
-
+  board: 14 # project number from create-board.sh — update after running it
+  created: "2026-03-29T19:29:02Z"
+  milestone: 1
 stories:
   - planning/stories/ci-baseline-build-and-test.yml
   - planning/stories/add-contributing-pr-template.yml

--- a/planning/stories/add-contributing-pr-template.yml
+++ b/planning/stories/add-contributing-pr-template.yml
@@ -7,13 +7,13 @@ branch: chore/sprint0-contributing-templates
 description: |
   Add foundational repo documentation: CONTRIBUTING guide,
   pull request template, and .gitignore for .NET projects.
-
 tasks:
   - Add CONTRIBUTING.md
   - Add .github/PULL_REQUEST_TEMPLATE.md
   - Add .gitignore for .NET
-
 acceptance:
   - CONTRIBUTING.md exists at repo root
   - PR template auto-populates on new PRs
   - .gitignore covers bin/, obj/, .vs/
+created: "2026-03-29T19:27:00Z"
+issue_number: 6

--- a/planning/stories/add-dotnet-solution-skeleton.yml
+++ b/planning/stories/add-dotnet-solution-skeleton.yml
@@ -7,14 +7,14 @@ branch: chore/sprint0-solution-skeleton
 description: |
   Create the .NET solution file, API project, and test project
   with a passing health check endpoint and one green test.
-
 tasks:
   - Create CampFitFurDogs.sln
   - Add src/CampFitFurDogs.Api project
   - Add tests/CampFitFurDogs.Api.Tests project
   - Add one passing health check test
-
 acceptance:
   - Solution builds with dotnet build
   - dotnet test passes with at least one test
   - API starts and returns 200 on /health
+created: "2026-03-29T19:27:09Z"
+issue_number: 7

--- a/planning/stories/ci-baseline-build-and-test.yml
+++ b/planning/stories/ci-baseline-build-and-test.yml
@@ -7,12 +7,12 @@ branch: chore/sprint0-ci-baseline
 description: |
   Add a minimal GitHub Actions workflow that builds the .NET
   solution and runs tests on every PR to main.
-
 tasks:
   - Create .github/workflows/ci.yml
   - Add restore, build, test steps
   - Add markdown lint step
-
 acceptance:
   - Workflow triggers on PRs to main
   - Passes on a test PR
+created: "2026-03-29T19:27:17Z"
+issue_number: 8


### PR DESCRIPTION
## What

Records the \\created\\ timestamps stamped into epic, story, and sprint YAML files by the planning engines after successful GitHub issue/milestone creation.

### Why
These timestamps are idempotency guards — each engine skips manifests that already have a \\created\\ field, preventing duplicate issues and milestones on re-runs.
