### PR TITLE
Refactor: extract shared lib + harden creation scripts

### DIFF
--- a/.github/scripts/create-epics.sh
+++ b/.github/scripts/create-epics.sh
@@ -1,51 +1,44 @@
 #!/usr/bin/env bash
-# create-epics.sh — Creates GitHub issues for epics defined in YAML files.
+# create-epics.sh — Creates GitHub issues for epics.
 #
 # Usage:
-#   ./create-epics.sh <file.yml>          # single epic
-#   ./create-epics.sh <directory/>        # all epics in directory
-#   ./create-epics.sh epics/*.yml         # glob
-#
-# Prerequisites:
-#   - gh CLI authenticated (gh auth login)
-#   - yq v4+ installed (https://github.com/mikefarah/yq)
+#   ./create-epics.sh [--dry-run] <file.yml|directory/>
 #
 # Idempotent: skips files already stamped with 'epic.created'.
-# Labels are auto-created if they don't already exist in the repo.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/repo.env"
+source "$SCRIPT_DIR/lib.sh"
 
-# --- Functions ---
-
-# Auto-create labels that don't yet exist in the repo.
-# Accepts a comma-separated label string (as produced by yq join).
-ensure_labels() {
-  local labels_csv="$1"
-  [[ -z "$labels_csv" ]] && return 0
-
-  IFS=',' read -ra label_array <<< "$labels_csv"
-  for label in "${label_array[@]}"; do
-    label=$(echo "$label" | xargs)  # trim whitespace
-    [[ -z "$label" ]] && continue
-    if gh label create "$label" --repo "$FULL_REPO" 2>/dev/null; then
-      echo "  🏷  Created label: $label"
-    fi
-  done
+show_help() {
+  echo "Usage: create-epics.sh [--dry-run] <file.yml|directory/>"
+  echo ""
+  echo "Creates GitHub issues for epics defined in YAML manifests."
+  echo "Idempotent — skips files already stamped with 'epic.created'."
+  echo ""
+  echo "Options:"
+  echo "  --dry-run   Show what would be created without making API calls"
+  echo "  --help, -h  Show this help message"
+  echo ""
+  echo "Environment:"
+  echo "  PROJECT_NUMBER  Board number (default: 14, from repo.env)"
+  exit 0
 }
 
 create_epic() {
   local file="$1"
+  CURRENT_FILE="$file"
 
-  # Idempotency check
+  CURRENT_STEP="checking idempotency stamp"
   if yq -e '.epic.created' "$file" &>/dev/null; then
-    echo "⏭  Skipping $(basename "$file") — already created"
+    echo "⏭ Skipping $(basename "$file") — already created"
     return 0
   fi
 
+  CURRENT_STEP="reading manifest"
   local title description labels
   title=$(yq -r '.epic.title' "$file")
   description=$(yq -r '.epic.description // ""' "$file")
@@ -53,21 +46,34 @@ create_epic() {
 
   echo "🔨 Creating epic: $title"
 
-  # Ensure labels exist
   [[ -n "$labels" ]] && ensure_labels "$labels"
 
-  # Create the issue
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  [dry-run] Would create issue: $title"
+    echo "  [dry-run] Would add to board #$PROJECT_NUMBER"
+    return 0
+  fi
+
+  CURRENT_STEP="creating GitHub issue"
+  local -a label_args=()
+  [[ -n "$labels" ]] && label_args=(--label "$labels")
+
   local issue_url
   issue_url=$(gh issue create \
     --repo "$FULL_REPO" \
     --title "$title" \
     --body "$description" \
-    ${labels:+--label "$labels"})
+    "${label_args[@]}")
 
   local issue_number
   issue_number=$(basename "$issue_url")
 
-  # Stamp the file
+  CURRENT_STEP="adding to project board"
+  require_board
+  add_to_board "$PROJECT_ID" "$issue_number"
+  echo "  📋 Added to board #$PROJECT_NUMBER"
+
+  CURRENT_STEP="stamping manifest"
   local now
   now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   yq -i ".epic.created = \"$now\" | .epic.issue_number = $issue_number" "$file"
@@ -76,10 +82,13 @@ create_epic() {
 }
 
 # --- Main ---
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && show_help
+
+parse_flags "$@"
+set -- "${REMAINING_ARGS[@]}"
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: create-epics.sh <file.yml|directory/>"
-  exit 1
+  show_help
 fi
 
 for arg in "$@"; do
@@ -90,6 +99,6 @@ for arg in "$@"; do
   elif [[ -f "$arg" ]]; then
     create_epic "$arg"
   else
-    echo "⚠  Not found: $arg"
+    echo "⚠ Not found: $arg"
   fi
 done

--- a/.github/scripts/create-sprint.sh
+++ b/.github/scripts/create-sprint.sh
@@ -1,90 +1,85 @@
 #!/usr/bin/env bash
 # create-sprint.sh — Creates a GitHub milestone for a sprint and assigns
-#                     stories to the milestone and an existing project board.
+# stories to the milestone and project board.
 #
 # Usage:
-#   ./create-sprint.sh sprints/sprint-0.yml
-#
-# What it does:
-#   1. Creates a milestone with the sprint end date as due date
-#   2. For each story listed in the manifest:
-#      - Creates the story issue if not yet created (delegates to create-stories.sh)
-#      - Assigns the issue to the milestone
-#      - Adds the issue to the existing project board (read from sprint.board)
-#
-# Prerequisites:
-#   - gh CLI authenticated (gh auth login)
-#   - yq v4+ installed (https://github.com/mikefarah/yq)
-#   - jq installed
-#   - Project board must already exist (run create-board.sh first)
-#   - sprint.board field must be set to the project number in the sprint YAML
+#   ./create-sprint.sh [--dry-run] <sprint-file.yml>
 #
 # Idempotent: skips if sprint.created is already stamped.
-# Re-running after adding stories to the manifest will NOT process new stories
-# because the sprint-level stamp gates the entire run.
-# For carry-over, list the story in the next sprint manifest — the story's
-# own stamp prevents re-creation, and milestone reassignment is the goal.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/repo.env"
+source "$SCRIPT_DIR/lib.sh"
 
-# --- Functions ---
-
-# Resolve the project board's node ID from its number.
-# The GraphQL addProjectV2ItemById mutation needs the node ID, not the number.
-resolve_project_id() {
-  local project_number="$1"
-  gh api graphql -f query="
-    query {
-      user(login: \"$OWNER\") {
-        projectV2(number: $project_number) {
-          id
-        }
-      }
-    }" --jq '.data.user.projectV2.id'
+show_help() {
+  echo "Usage: create-sprint.sh [--dry-run] <sprint-file.yml>"
+  echo ""
+  echo "Creates a GitHub milestone for a sprint, creates story issues,"
+  echo "assigns them to the milestone, and adds them to the project board."
+  echo "Idempotent — skips if sprint.created is already stamped."
+  echo ""
+  echo "Options:"
+  echo "  --dry-run   Show what would be created without making API calls"
+  echo "  --help, -h  Show this help message"
+  echo ""
+  echo "Environment:"
+  echo "  PROJECT_NUMBER  Board number (default: 14, from repo.env)"
+  exit 0
 }
 
 create_sprint() {
   local file="$1"
+  CURRENT_FILE="$file"
 
-  # Idempotency check
+  CURRENT_STEP="checking idempotency stamp"
   if yq -e '.sprint.created' "$file" &>/dev/null; then
-    echo "⏭  Skipping $(basename "$file") — already created"
+    echo "⏭ Skipping $(basename "$file") — already created"
     return 0
   fi
 
-  local name title end_date board_number
+  CURRENT_STEP="reading manifest"
+  local name title end_date
   name=$(yq -r '.sprint.name' "$file")
   title=$(yq -r '.sprint.title // .sprint.name' "$file")
   end_date=$(yq -r '.sprint.end' "$file")
-  board_number=$(yq -r '.sprint.board' "$file")
-
-  # Validate board number
-  if [[ -z "$board_number" || "$board_number" == "null" ]]; then
-    echo "❌ Error: sprint.board is not set in $file"
-    echo "   Run create-board.sh first, then add 'board: <number>' to your sprint YAML."
-    exit 1
-  fi
 
   echo "🏃 Creating sprint: $title"
   echo ""
 
-  # --- 1. Resolve Project Board Node ID ---
-  echo "  📋 Looking up project board #$board_number"
-  local project_id
-  project_id=$(resolve_project_id "$board_number")
+  CURRENT_STEP="resolving project board"
+  require_board
+  echo "  📋 Board #$PROJECT_NUMBER resolved"
 
-  if [[ -z "$project_id" || "$project_id" == "null" ]]; then
-    echo "❌ Error: Could not find project board #$board_number"
-    echo "   Verify the board exists: gh project view $board_number --owner $OWNER"
-    exit 1
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  [dry-run] Would create milestone: $name (due $end_date)"
+
+    local story_count
+    story_count=$(yq -r '.stories | length' "$file")
+
+    for i in $(seq 0 $((story_count - 1))); do
+      local story_path
+      story_path=$(yq -r ".stories[$i]" "$file")
+      local full_path="$REPO_ROOT/$story_path"
+
+      if [[ ! -f "$full_path" ]]; then
+        echo "  [dry-run] ⚠ Story not found: $story_path"
+        continue
+      fi
+
+      local story_title
+      story_title=$(yq -r '.title' "$full_path")
+      echo "  [dry-run] Would process story: $story_title"
+    done
+
+    echo ""
+    echo "🏜 Dry run complete — $story_count stories would be processed"
+    return 0
   fi
-  echo "     → Board resolved"
 
-  # --- 2. Create Milestone ---
+  CURRENT_STEP="creating milestone"
   echo "  📌 Creating milestone: $name"
   local milestone_number
   milestone_number=$(gh api "repos/$FULL_REPO/milestones" \
@@ -93,9 +88,8 @@ create_sprint() {
     -f description="$title" \
     -f due_on="${end_date}T23:59:59Z" \
     --jq '.number')
-  echo "     → Milestone #$milestone_number"
+  echo "  → Milestone #$milestone_number"
 
-  # --- 3. Process Stories ---
   echo ""
   local story_count
   story_count=$(yq -r '.stories | length' "$file")
@@ -106,65 +100,57 @@ create_sprint() {
     local full_path="$REPO_ROOT/$story_path"
 
     if [[ ! -f "$full_path" ]]; then
-      echo "  ⚠  Story not found: $story_path — skipping"
+      echo "  ⚠ Story not found: $story_path — skipping"
       continue
     fi
 
     local story_title
     story_title=$(yq -r '.title' "$full_path")
 
-    # Create story if not yet created
+    CURRENT_STEP="creating story: $story_title"
     if ! yq -e '.created' "$full_path" &>/dev/null; then
       "$SCRIPT_DIR/create-stories.sh" "$full_path"
     else
-      echo "  ⏭  Story already exists: $story_title"
+      echo "  ⏭ Story already exists: $story_title"
     fi
 
     local issue_number
     issue_number=$(yq -r '.issue_number' "$full_path")
 
-    # Assign to milestone
+    CURRENT_STEP="assigning #$issue_number to milestone"
     gh issue edit "$issue_number" \
       --repo "$FULL_REPO" \
       --milestone "$name" > /dev/null
 
-    # Add to project board (idempotent — GitHub ignores duplicates)
-    local issue_node_id
-    issue_node_id=$(gh api "repos/$FULL_REPO/issues/$issue_number" --jq '.node_id')
+    CURRENT_STEP="adding #$issue_number to board"
+    add_to_board "$PROJECT_ID" "$issue_number"
 
-    gh api graphql -f query="
-      mutation {
-        addProjectV2ItemById(input: {
-          projectId: \"$project_id\"
-          contentId: \"$issue_node_id\"
-        }) {
-          item { id }
-        }
-      }" --silent
-
-    echo "     → #$issue_number assigned to milestone + board"
+    echo "  → #$issue_number assigned to milestone + board"
   done
 
-  # --- 4. Stamp the sprint file ---
+  CURRENT_STEP="stamping manifest"
   local now
   now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   yq -i "
-    .sprint.created = \"$now\" |
-    .sprint.milestone = $milestone_number
+    .sprint.created = \"$now\"
+    | .sprint.milestone = $milestone_number
   " "$file"
 
   echo ""
   echo "✅ Sprint created: $title"
   echo "   Milestone: #$milestone_number"
-  echo "   Board:     #$board_number (pre-existing)"
+  echo "   Board:     #$PROJECT_NUMBER"
   echo "   Stories:   $story_count processed"
 }
 
 # --- Main ---
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && show_help
+
+parse_flags "$@"
+set -- "${REMAINING_ARGS[@]}"
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: create-sprint.sh <sprint-file.yml>"
-  exit 1
+  show_help
 fi
 
 create_sprint "$1"

--- a/.github/scripts/create-stories.sh
+++ b/.github/scripts/create-stories.sh
@@ -1,45 +1,34 @@
 #!/usr/bin/env bash
-# create-stories.sh — Creates GitHub issues for stories defined in YAML files.
+# create-stories.sh — Creates GitHub issues for stories.
 #
 # Usage:
-#   ./create-stories.sh <file.yml>          # single story
-#   ./create-stories.sh <directory/>        # all stories in directory
-#   ./create-stories.sh stories/*.yml       # glob
-#
-# Prerequisites:
-#   - gh CLI authenticated (gh auth login)
-#   - yq v4+ installed (https://github.com/mikefarah/yq)
-#   - Run create-epics.sh first if stories reference epics
+#   ./create-stories.sh [--dry-run] <file.yml|directory/>
 #
 # Idempotent: skips files already stamped with 'created'.
-# Labels are auto-created if they don't already exist in the repo.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/repo.env"
+source "$SCRIPT_DIR/lib.sh"
 
-# --- Functions ---
-
-# Auto-create labels that don't yet exist in the repo.
-# Accepts a comma-separated label string (as produced by yq join).
-ensure_labels() {
-  local labels_csv="$1"
-  [[ -z "$labels_csv" ]] && return 0
-
-  IFS=',' read -ra label_array <<< "$labels_csv"
-  for label in "${label_array[@]}"; do
-    label=$(echo "$label" | xargs)  # trim whitespace
-    [[ -z "$label" ]] && continue
-    if gh label create "$label" --repo "$FULL_REPO" 2>/dev/null; then
-      echo "  🏷  Created label: $label"
-    fi
-  done
+show_help() {
+  echo "Usage: create-stories.sh [--dry-run] <file.yml|directory/>"
+  echo ""
+  echo "Creates GitHub issues for stories defined in YAML manifests."
+  echo "Idempotent — skips files already stamped with 'created'."
+  echo ""
+  echo "Options:"
+  echo "  --dry-run   Show what would be created without making API calls"
+  echo "  --help, -h  Show this help message"
+  echo ""
+  echo "Environment:"
+  echo "  PROJECT_NUMBER  Board number (default: 14, from repo.env)"
+  exit 0
 }
 
-# Search local epic YAML files to find the GitHub issue number for an epic title.
-# Returns the issue number or empty string if not found/not yet created.
+# Search local epic YAMLs for an epic's issue number by title.
 find_epic_issue() {
   local epic_title="$1"
   local epics_dir="$REPO_ROOT/$EPICS_DIR"
@@ -56,24 +45,14 @@ find_epic_issue() {
   echo ""
 }
 
-# Build the GitHub issue body from YAML fields:
-#   - description text
-#   - epic cross-reference (if epic exists)
-#   - tasks as checkboxes
-#   - acceptance criteria as checkboxes
 build_body() {
   local file="$1"
   local body=""
 
-  # Description
   local description
   description=$(yq -r '.description // ""' "$file")
-  if [[ -n "$description" ]]; then
-    body+="$description"
-    body+=$'\n'
-  fi
+  [[ -n "$description" ]] && body+="$description"$'\n'
 
-  # Epic cross-reference
   local epic_title
   epic_title=$(yq -r '.epic // ""' "$file")
   if [[ -n "$epic_title" ]]; then
@@ -86,27 +65,21 @@ build_body() {
     fi
   fi
 
-  # Tasks as checkboxes
   local task_count
   task_count=$(yq -r '.tasks | length' "$file")
   if [[ "$task_count" -gt 0 ]]; then
     body+=$'\n'"## Tasks"$'\n'
     for i in $(seq 0 $((task_count - 1))); do
-      local task
-      task=$(yq -r ".tasks[$i]" "$file")
-      body+="- [ ] $task"$'\n'
+      body+="- [ ] $(yq -r ".tasks[$i]" "$file")"$'\n'
     done
   fi
 
-  # Acceptance criteria as checkboxes
   local ac_count
   ac_count=$(yq -r '.acceptance | length' "$file")
   if [[ "$ac_count" -gt 0 ]]; then
     body+=$'\n'"## Acceptance Criteria"$'\n'
     for i in $(seq 0 $((ac_count - 1))); do
-      local criterion
-      criterion=$(yq -r ".acceptance[$i]" "$file")
-      body+="- [ ] $criterion"$'\n'
+      body+="- [ ] $(yq -r ".acceptance[$i]" "$file")"$'\n'
     done
   fi
 
@@ -115,38 +88,53 @@ build_body() {
 
 create_story() {
   local file="$1"
+  CURRENT_FILE="$file"
 
-  # Idempotency check
+  CURRENT_STEP="checking idempotency stamp"
   if yq -e '.created' "$file" &>/dev/null; then
-    echo "⏭  Skipping $(basename "$file") — already created"
+    echo "⏭ Skipping $(basename "$file") — already created"
     return 0
   fi
 
+  CURRENT_STEP="reading manifest"
   local title labels
   title=$(yq -r '.title' "$file")
   labels=$(yq -r '(.labels // []) | join(",")' "$file")
 
   echo "🔨 Creating story: $title"
 
-  # Ensure labels exist
   [[ -n "$labels" ]] && ensure_labels "$labels"
 
-  # Build issue body
+  CURRENT_STEP="building issue body"
   local body
   body=$(build_body "$file")
 
-  # Create the issue
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  [dry-run] Would create issue: $title"
+    echo "  [dry-run] Would add to board #$PROJECT_NUMBER"
+    return 0
+  fi
+
+  CURRENT_STEP="creating GitHub issue"
+  local -a label_args=()
+  [[ -n "$labels" ]] && label_args=(--label "$labels")
+
   local issue_url
   issue_url=$(gh issue create \
     --repo "$FULL_REPO" \
     --title "$title" \
     --body "$body" \
-    ${labels:+--label "$labels"})
+    "${label_args[@]}")
 
   local issue_number
   issue_number=$(basename "$issue_url")
 
-  # Stamp the file
+  CURRENT_STEP="adding to project board"
+  require_board
+  add_to_board "$PROJECT_ID" "$issue_number"
+  echo "  📋 Added to board #$PROJECT_NUMBER"
+
+  CURRENT_STEP="stamping manifest"
   local now
   now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   yq -i ".created = \"$now\" | .issue_number = $issue_number" "$file"
@@ -155,10 +143,13 @@ create_story() {
 }
 
 # --- Main ---
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && show_help
+
+parse_flags "$@"
+set -- "${REMAINING_ARGS[@]}"
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: create-stories.sh <file.yml|directory/>"
-  exit 1
+  show_help
 fi
 
 for arg in "$@"; do
@@ -169,6 +160,6 @@ for arg in "$@"; do
   elif [[ -f "$arg" ]]; then
     create_story "$arg"
   else
-    echo "⚠  Not found: $arg"
+    echo "⚠ Not found: $arg"
   fi
 done

--- a/.github/scripts/lib.sh
+++ b/.github/scripts/lib.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# lib.sh — Shared functions for all creation engines.
+# Sourced by each script after repo.env.
+
+# --- Dependency Check ---
+
+require_tools() {
+  local missing=()
+  for cmd in gh yq jq; do
+    command -v "$cmd" &>/dev/null || missing+=("$cmd")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "❌ Missing required tools: ${missing[*]}"
+    echo "  Install them before running creation engines."
+    exit 1
+  fi
+}
+
+require_tools
+
+# --- Dry-Run Support ---
+
+DRY_RUN=false
+
+parse_flags() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run) DRY_RUN=true; shift ;;
+      *) break ;;
+    esac
+  done
+  REMAINING_ARGS=("$@")
+
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "🏜 Dry run — no issues or milestones will be created"
+    echo ""
+  fi
+}
+
+# --- Error Trap ---
+
+CURRENT_FILE=""
+CURRENT_STEP=""
+
+trap 'echo ""; echo "💥 Failed during: $CURRENT_STEP"; echo "   File: $CURRENT_FILE"; exit 1' ERR
+
+# --- Board Functions ---
+
+# Resolve the project board's node ID from its number.
+resolve_project_id() {
+  local project_number="$1"
+  gh api graphql -f query="
+    query {
+      user(login: \"$OWNER\") {
+        projectV2(number: $project_number) { id }
+      }
+    }" --jq '.data.user.projectV2.id'
+}
+
+# Add an issue to the project board. Idempotent.
+add_to_board() {
+  local project_id="$1"
+  local issue_number="$2"
+
+  local issue_node_id
+  issue_node_id=$(gh api "repos/$FULL_REPO/issues/$issue_number" --jq '.node_id')
+
+  gh api graphql -f query="
+    mutation {
+      addProjectV2ItemById(input: {
+        projectId: \"$project_id\"
+        contentId: \"$issue_node_id\"
+      }) { item { id } }
+    }" --silent
+}
+
+# Resolve and validate the project board. Sets PROJECT_ID in caller scope.
+require_board() {
+  CURRENT_STEP="resolving project board"
+
+  if [[ -z "${PROJECT_NUMBER:-}" ]]; then
+    echo "❌ Error: PROJECT_NUMBER is not set."
+    echo "  Set it in repo.env or export PROJECT_NUMBER=<number>"
+    exit 1
+  fi
+
+  PROJECT_ID=$(resolve_project_id "$PROJECT_NUMBER")
+
+  if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
+    echo "❌ Error: Could not find project board #$PROJECT_NUMBER"
+    echo "  Verify: gh project view $PROJECT_NUMBER --owner $OWNER"
+    exit 1
+  fi
+}
+
+# --- Label Functions ---
+
+# Auto-create labels that don't yet exist in the repo.
+ensure_labels() {
+  local labels_csv="$1"
+  [[ -z "$labels_csv" ]] && return 0
+
+  IFS=',' read -ra label_array <<< "$labels_csv"
+  for label in "${label_array[@]}"; do
+    label=$(echo "$label" | xargs)
+    [[ -z "$label" ]] && continue
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "  [dry-run] Would ensure label: $label"
+    elif gh label create "$label" --repo "$FULL_REPO" 2>/dev/null; then
+      echo "  🏷 Created label: $label"
+    fi
+  done
+}

--- a/.github/scripts/repo.env
+++ b/.github/scripts/repo.env
@@ -5,6 +5,9 @@ OWNER="frankjhughes"
 REPO="camp-fit-fur-dogs"
 FULL_REPO="${OWNER}/${REPO}"
 
+# Project board number — override with: export PROJECT_NUMBER=<n>
+PROJECT_NUMBER="${PROJECT_NUMBER:-14}"
+
 # Default directory paths (relative to repo root)
 EPICS_DIR="planning/epics"
 STORIES_DIR="planning/stories"


### PR DESCRIPTION
"## What

Extract shared functions into ``lib.sh``, replace hardcoded board number with ``PROJECT_NUMBER`` env var, and add defensive scripting best practices to all creation engines.

No issue to close — housekeeping refactor.

## Why

Shared functions (``resolve_project_id``, ``add_to_board``, ``ensure_labels``) were duplicated across scripts. The board number was read from a YAML field that coupled sprint manifests to infrastructure config. Scripts lacked dependency checks, dry-run support, and error context.

## How

- Created ``lib.sh`` with shared functions, dependency checks, dry-run flag parsing, and an ERR trap
- Added ``PROJECT_NUMBER`` to ``repo.env`` with a default of 14 (overridable via export)
- All three engines now source ``lib.sh`` and add issues to the board at creation time
- Safe quoting via ``label_args`` array pattern
- ``--help`` and ``--dry-run`` flags on every script

## Acceptance Criteria

- [x] ``lib.sh`` contains ``resolve_project_id``, ``add_to_board``, ``ensure_labels``, ``require_board``, ``require_tools``, ``parse_flags``
- [x] ``repo.env`` defines ``PROJECT_NUMBER`` with env-var override
- [x] ``create-sprint.sh`` no longer reads ``sprint.board`` from YAML
- [x] ``create-stories.sh`` and ``create-epics.sh`` add issues to the board
- [x] All scripts support ``--help`` and ``--dry-run``
- [x] ERR trap reports file and step on failure

## Testing

- [ ] ``create-sprint.sh --dry-run planning/sprints/sprint-1.yml`` — runs without errors
- [ ] ``create-stories.sh --help`` — prints usage
- [ ] ``create-epics.sh --help`` — prints usage
- [ ] Manual verification: scripts source ``lib.sh`` correctly and fail fast on missing tools

## Screenshots

N/A — CLI scripts only.