### PR TITLE
Sprint 1: Author Architecture Spine manifests

### DIFF
--- a/planning/sprints/sprint-1.yml
+++ b/planning/sprints/sprint-1.yml
@@ -1,0 +1,11 @@
+sprint:
+  name: "Sprint 1"
+  title: "Sprint 1 — Architecture Spine"
+  start: 2026-04-04
+  end: 2026-04-10
+
+stories:
+  - planning/stories/adr-foundation.yml
+  - planning/stories/shared-kernel-ddd-building-blocks.yml
+  - planning/stories/domain-model-core-aggregates.yml
+  - planning/stories/api-ddd-layer-wiring.yml

--- a/planning/stories/adr-foundation.yml
+++ b/planning/stories/adr-foundation.yml
@@ -1,0 +1,22 @@
+title: "ADR foundation"
+epic: "Epic: Repo Foundation"
+points: 2
+priority: P1
+labels: [docs, architecture]
+branch: feature/sprint1-adr-foundation
+description: |
+  Establish an Architecture Decision Record (ADR) practice with a
+  lightweight template and two seed records that capture decisions
+  already made. Future architectural choices will be recorded here
+  before implementation begins.
+tasks:
+  - Create docs/adr/ directory
+  - Add ADR template (docs/adr/TEMPLATE.md)
+  - Write ADR-001 "Use lightweight ADRs for architecture decisions"
+  - Write ADR-002 "DDD layered architecture with clean separation"
+  - Add a README index in docs/adr/README.md linking all ADRs
+acceptance:
+  - docs/adr/ directory exists with template and two seed ADRs
+  - ADR-001 records the decision to use ADRs and references the template
+  - ADR-002 documents the four-layer DDD structure matching the solution
+  - README.md lists all ADRs with status and one-line summary

--- a/planning/stories/api-ddd-layer-wiring.yml
+++ b/planning/stories/api-ddd-layer-wiring.yml
@@ -1,0 +1,24 @@
+title: "API: DDD layer wiring and dependency injection"
+epic: "Epic: Repo Foundation"
+points: 2
+priority: P2
+labels: [dotnet, infra, architecture]
+branch: feature/sprint1-api-layer-wiring
+description: |
+  Wire the DDD layers together through dependency injection in the
+  API project. Each layer gets a registration extension method that
+  the API host calls at startup. This proves the layer cake compiles
+  and resolves end-to-end without circular references.
+tasks:
+  - Add DomainServiceRegistration extension method in Domain project
+  - Add InfrastructureServiceRegistration extension method in Infrastructure project
+  - Add ApplicationServiceRegistration extension method in Application project
+  - Wire all three into Program.cs
+  - Add an integration test that builds the host and resolves a domain service
+acceptance:
+  - Each DDD layer has a single AddXxx(IServiceCollection) extension method
+  - Program.cs calls all three registration methods
+  - API starts without DI resolution errors
+  - Integration test proves at least one cross-layer dependency resolves
+  - No circular project references exist
+  - dotnet build produces zero warnings

--- a/planning/stories/domain-model-core-aggregates.yml
+++ b/planning/stories/domain-model-core-aggregates.yml
@@ -1,0 +1,24 @@
+title: "Domain model: core aggregates"
+epic: "Epic: Repo Foundation"
+points: 5
+priority: P1
+labels: [dotnet, domain]
+branch: feature/sprint1-core-aggregates
+description: |
+  Define the first two aggregate roots — Dog and Guardian — in the
+  Domain project. Each gets a strongly-typed identity value object.
+  These are persistence-ignorant; EF Core mapping comes in a later sprint.
+tasks:
+  - Add DogId value object wrapping Guid
+  - Add Dog aggregate root with Name, Breed, DateOfBirth, GuardianId
+  - Add GuardianId value object wrapping Guid
+  - Add Guardian aggregate root with FirstName, LastName, Email, Phone
+  - Add Guard clauses for required fields (no empty names, no default Guids)
+  - Add unit tests for Dog creation, Guardian creation, and guard clause enforcement
+acceptance:
+  - Dog and Guardian are AggregateRoot<TId> subclasses in the Domain project
+  - DogId and GuardianId are ValueObject subclasses
+  - Constructing a Dog or Guardian with invalid data throws ArgumentException
+  - Dog holds a GuardianId reference (not a navigation property)
+  - All aggregate tests pass
+  - dotnet build produces zero warnings

--- a/planning/stories/shared-kernel-ddd-building-blocks.yml
+++ b/planning/stories/shared-kernel-ddd-building-blocks.yml
@@ -1,0 +1,25 @@
+title: "Shared kernel: DDD building blocks"
+epic: "Epic: Repo Foundation"
+points: 3
+priority: P1
+labels: [dotnet, architecture, domain]
+branch: feature/sprint1-shared-kernel
+description: |
+  Add base types to the SharedKernel project that all domain models
+  will inherit from. These are the building blocks of the domain layer:
+  identity-typed entities, aggregate roots with domain event support,
+  value objects with structural equality, and a repository contract.
+tasks:
+  - Add Entity<TId> base class with identity equality
+  - Add AggregateRoot<TId> extending Entity with domain event collection
+  - Add ValueObject base class with structural equality via GetEqualityComponents()
+  - Add IDomainEvent marker interface
+  - Add IRepository<T> interface (GetById, Add, Update, Delete)
+  - Add unit tests for Entity equality, ValueObject equality, and AggregateRoot event collection
+acceptance:
+  - SharedKernel project contains Entity, AggregateRoot, ValueObject, IDomainEvent, IRepository
+  - Entity equality is based on Id, not reference
+  - ValueObject equality is based on component values
+  - AggregateRoot can register and clear domain events
+  - All building block types have passing unit tests
+  - dotnet build produces zero warnings


### PR DESCRIPTION
## What

Author story YAMLs and sprint manifest for Sprint 1 — Architecture Spine.

## Why

Sprint 0 delivered the repo skeleton, CI, and templates. Sprint 1 builds the
architecture spine: ADR practice, DDD base types, first aggregates, and
layer wiring.

## How

- 4 story YAMLs in `planning/stories/`
- 1 sprint manifest in `planning/sprints/sprint-1.yml`
- No `board` field in manifest — uses `PROJECT_NUMBER` env var from repo.env

## Acceptance Criteria

- [x] All 4 story YAMLs follow the Sprint 0 schema (title, epic, points, priority, labels, branch, description, tasks, acceptance)
- [x] Sprint manifest references all 4 stories by path
- [x] No `board` field in sprint manifest (uses `PROJECT_NUMBER` env var)
- [x] Sprint dates: Apr 4–10, 2026

## Testing

~~~bash
# Dry run after merging script-hardening PR
bash .github/scripts/create-sprint.sh --dry-run planning/sprints/sprint-1.yml
~~~

## Screenshots

N/A — YAML manifests only.