### PR TITLE
docs: surface milestones across stakeholder touchpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,20 @@ This project is part of a personal portfolio and is not licensed for commercial 
 
 ## Current Status
 
-| Sprint | Focus | Status |
-|--------|-------|--------|
-| Sprint 0 | Repo bootstrap, .NET skeleton, CI baseline | Completed |
-| Sprint 1 | DDD architecture vertical (SharedKernel, Domain, API wiring) | Completed |
-| Sprint 2 | DX toolchain, doc audit, planning retirement, backlog grooming | Completed |
-| Sprint 3 | First customer feature | Planning |
+**Engineering foundation is complete.** DDD architecture, CI pipeline,
+developer environment, and governance shipped across Sprints 0-2.
+Customer features are unblocked.
 
-**Backlog:** 22 stories remaining | **Completed:** 17 | **Retired:** 2 | **Absorbed:** 2
-**ADRs:** 10 | **Next available story:** US-045
+### Milestone Progress
 
-See [CHANGELOG.md](CHANGELOG.md) for detailed history.
+| Milestone | Goal | Stories | Status |
+|-----------|------|---------|--------|
+| [M1: First Customer Vertical](../../milestones) | Create account, register dog, view profile | 3 | Not started |
+| [M2: Complete Dog Management](../../milestones) | Full dog CRUD with graceful edge cases | 7 | Not started |
+| [M3: Portfolio Showcase](../../milestones) | Docs, tooling, onboarding ready for review | 4 | Not started |
+
+**22 stories remaining** across 3 milestones | **17 completed** | **10 ADRs** | Next story: US-045
+
+[Milestone Tracker](https://github.com/frankjhughes/camp-fit-fur-dogs/milestones) ·
+[Sprint History](CHANGELOG.md) ·
+[Sprint Board](https://github.com/frankjhughes/camp-fit-fur-dogs/projects/14)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,19 @@ Quick reference for all project documentation.
 | [Runbooks](runbooks/) | Local setup, migrations, deployments, incident response |
 | [Sprint Reviews](sprint-reviews/) | Sprint-by-sprint progress and retrospectives |
 | [Changelog](../CHANGELOG.md) | All notable changes by sprint |
+
+---
+
+## Roadmap
+
+Progress is tracked through capability milestones, not sprints.
+Each milestone represents a demonstrable capability — a moment where
+the system can do something new and meaningful.
+
+| Milestone | What It Proves |
+|-----------|---------------|
+| **M1: First Customer Vertical** | The architecture serves a real use case end-to-end |
+| **M2: Complete Dog Management** | The product handles real-world complexity with emotional safety |
+| **M3: Portfolio Showcase** | The project is fully documented and onboardable |
+
+[View milestone progress on GitHub](https://github.com/frankjhughes/camp-fit-fur-dogs/milestones)

--- a/portfolio/SURFACING-STRATEGY.md
+++ b/portfolio/SURFACING-STRATEGY.md
@@ -1,6 +1,7 @@
 # Surfacing Strategy
 
-> How portfolio artifacts travel from the repo to an evaluator's screen.
+> How portfolio artifacts travel from the repo to an evaluator's screen,
+> organized around capability milestones.
 
 ---
 
@@ -10,57 +11,72 @@
    the repo root `README.md` within one click.
 2. **Layered depth** — surface a summary first, link to detail second.
    Respect evaluator time.
-3. **Living proof** — link to the actual sprint board, CI runs, and merged
-   PRs. Static screenshots are supplements, not substitutes.
-4. **Narrative arc** — each case study follows Problem → Approach →
-   Outcome → Reflection.
+3. **Living proof** — link to the actual milestone tracker, CI runs, and
+   merged PRs. Static screenshots are supplements, not substitutes.
+4. **Narrative arc** — the project tells a progression story through
+   milestones: foundation → first feature → full product → showcase.
+
+---
+
+## Milestone-Driven Narrative
+
+Each milestone unlocks a new level of demonstrable capability:
+
+| Milestone | What an Evaluator Sees | Key Artifacts |
+|-----------|----------------------|---------------|
+| M0 (done) | Engineering foundation, architecture, CI, governance | `docs/adr/`, `.github/workflows/`, `CONTRIBUTING.md` |
+| M1 | First working feature end-to-end through DDD layers | `src/`, domain tests, API endpoints |
+| M2 | Product maturity — edge cases handled with emotional safety | Product stories, sprint reviews, test coverage |
+| M3 | Fully documented, tooled, onboardable project | `docs/runbooks/`, developer guide, scaffold tool |
+
+The milestone tracker is the single source of truth for project progress:
+https://github.com/frankjhughes/camp-fit-fur-dogs/milestones
 
 ---
 
 ## Channel Map
 
 | Channel | What to Surface | Link Target |
-|---|---|---|
-| Repo root `README.md` | Project summary, architecture badge, "Portfolio" section with link | `/portfolio/README.md` |
-| LinkedIn Featured section | Case-study PDF or Loom demo link | `/portfolio/case-studies/*.md` or hosted URL |
-| Résumé / CV | Repo URL + one-line project description | Repo root |
+|---------|----------------|-------------|
+| Repo root `README.md` | Milestone progress table, architecture summary | Milestone tracker, `portfolio/README.md` |
+| LinkedIn Featured section | Repo link with milestone status callout | Repo root |
+| Resume / CV | Repo URL + current milestone + one-line description | Repo root |
 | GitHub Profile README | Pinned repo with descriptive tagline | Repo root |
-| Portfolio website (future) | Embedded demos, case-study pages | `/portfolio/demos/`, `/portfolio/case-studies/` |
+| Portfolio website (future) | Embedded milestone progress, case study pages | Milestone tracker, `portfolio/` |
 
 ---
 
 ## Repo Root README Additions
 
-Add a **Portfolio** section to the repo root `README.md`:
+The repo root `README.md` includes:
 
-```markdown
-## 📂 Portfolio
-
-This project doubles as a professional portfolio. Explore curated
-artifacts demonstrating product ownership, technical architecture,
-Agile process leadership, and creative direction.
-
-→ [Portfolio Index](portfolio/README.md)
-```
+- **Milestone Progress** table with links to GitHub Milestones
+- **Sprint History** link to `CHANGELOG.md`
+- **Sprint Board** link to GitHub Projects
+- **Portfolio** section linking to `portfolio/README.md`
 
 ---
 
 ## Maintenance Cadence
 
-| Action | Frequency |
-|---|---|
-| Update case studies after feature ships | Per sprint |
-| Refresh screenshots after UI changes | As needed |
-| Record new demo after milestone | Per milestone |
-| Review and prune stale artifacts | Monthly |
+| Action | Trigger | Frequency |
+|--------|---------|-----------|
+| Update milestone progress in README | Story completed | Per sprint |
+| Update sprint review | Sprint ends | Per sprint |
+| Update CHANGELOG | PR merged | Per PR |
+| Record demo or write case study | Milestone completed | Per milestone |
+| Review and prune stale artifacts | Calendar reminder | Monthly |
+| Create new sprint labels | Sprint planning | Per sprint |
 
 ---
 
 ## Anti-Patterns to Avoid
 
 - **Dead links** — CI should lint internal markdown links.
-- **Orphaned artifacts** — every file in `/portfolio/` must be linked from
+- **Orphaned artifacts** — every file in `portfolio/` must be linked from
   the portfolio `README.md`.
-- **Stale screenshots** — a screenshot older than two sprints without a
-  refresh note signals neglect.
+- **Sprint-centric communication** — stakeholders care about capability
+  milestones ("can it register a dog?"), not timeboxes ("Sprint 3 ended").
+- **Stale milestone counts** — README status section must stay current
+  with actual milestone progress on GitHub.
 - **Wall of text** — case studies over 800 words need an executive summary.

--- a/portfolio/USE-CASES.md
+++ b/portfolio/USE-CASES.md
@@ -1,7 +1,7 @@
 # Portfolio Use Cases
 
 > How Camp Fit Fur Dogs artifacts surface professional capability to
-> potential employers.
+> potential employers — organized around project milestones.
 
 ---
 
@@ -9,18 +9,21 @@
 
 **Actor:** Non-technical hiring manager
 
-**Trigger:** Clicks GitHub link on résumé or LinkedIn.
+**Trigger:** Clicks GitHub link on resume or LinkedIn.
 
 **Flow:**
-1. Lands on repo root → reads `README.md` (project summary, tech stack,
-   architecture diagram link).
-2. Navigates to `/portfolio/README.md` → sees curated index of
+1. Lands on repo root → reads `README.md` — project summary, milestone
+   progress table, and engineering practices overview.
+2. Sees milestone tracker link → clicks through to GitHub Milestones page
+   → sees progress bars for M1, M2, M3.
+3. Navigates to `portfolio/README.md` → sees curated index of
    portfolio-relevant artifacts.
-3. Opens a case study in `/portfolio/case-studies/` → reads a narrative
-   walkthrough of a feature from problem → solution → outcome.
+4. Reviews `product/VISION.md` → understands product thinking and
+   emotional safety commitments.
 
 **Success:** Manager understands scope, quality bar, and Frank's role
-within 3 minutes.
+within 3 minutes. Milestone progress shows the project is actively
+advancing, not abandoned.
 
 ---
 
@@ -31,16 +34,20 @@ within 3 minutes.
 **Trigger:** Asked to evaluate candidate's technical ability.
 
 **Flow:**
-1. Opens `/docs/architecture/` → reviews DDD folder structure, dependency
-   diagrams, handler registration patterns.
-2. Opens `/portfolio/demos/` → watches a 90-second screen recording of the
-   running application.
-3. Inspects CI/CD pipeline config → confirms deterministic builds, test
-   gates, merge checklists.
-4. Reads recent PRs → evaluates commit hygiene, PR descriptions, review
-   responsiveness.
+1. Opens `docs/adr/` → reviews 10 Architecture Decision Records covering
+   DDD layers, DX toolchain, infrastructure, and governance choices.
+2. Inspects `src/` → sees clean DDD layer separation (Api, Application,
+   Domain, Infrastructure, SharedKernel).
+3. Opens milestone M1 on GitHub → sees which stories are in progress and
+   how domain aggregates map to customer-facing features.
+4. Inspects CI/CD pipeline (`.github/workflows/ci.yaml`) → confirms
+   deterministic builds and test gates.
+5. Reads recent PRs → evaluates commit hygiene, PR descriptions, and
+   branch discipline.
 
-**Success:** Evaluator confirms production-grade engineering practices.
+**Success:** Evaluator confirms production-grade engineering practices
+and sees a DDD implementation serving real domain operations, not just
+a scaffold.
 
 ---
 
@@ -51,14 +58,21 @@ within 3 minutes.
 **Trigger:** Interview prep or async evaluation.
 
 **Flow:**
-1. Opens `/docs/backlog/` → reviews story-first YAML files, capability
-   map, emotional-safety guarantees.
-2. Opens GitHub Projects board → sees sprint cadence, WIP limits, done
-   criteria.
-3. Opens `/docs/governance/` → reads living governance document, sees
-   versioned process decisions.
+1. Opens `product/stories/` → reviews story-first markdown backlog,
+   capability themes, and emotional safety guarantees.
+2. Opens milestone tracker → sees how 22 remaining stories are organized
+   into three capability milestones (not just sprints).
+3. Opens GitHub Projects board → sees sprint cadence and issue lifecycle.
+4. Opens `docs/governance/governance.md` → reads living governance
+   document with versioned process decisions.
+5. Opens `CONTRIBUTING.md` → sees 2-step story workflow (story file as
+   backlog, issue as sprint commitment).
+6. Opens `docs/sprint-reviews/sprint-2.md` → sees structured retro with
+   honest "what could improve" section.
 
-**Success:** Interviewer validates Agile fluency and stakeholder empathy.
+**Success:** Interviewer validates Agile fluency, stakeholder empathy,
+and the discipline to separate planning cadence (sprints) from
+capability goals (milestones).
 
 ---
 
@@ -69,10 +83,14 @@ within 3 minutes.
 **Trigger:** Portfolio review for hybrid roles.
 
 **Flow:**
-1. Opens `/portfolio/screenshots/` → sees annotated UI compositions,
-   style explorations, brand treatments.
-2. Opens `/portfolio/presentations/` → reviews a slide deck summarizing
-   design rationale.
+1. Opens `product/emotional-guarantees/` → sees design principles that
+   prioritize user emotional safety alongside functionality.
+2. Reviews milestone M2 stories → sees edge case handling driven by
+   empathy, not just requirements (e.g., "Reassurance on Failure,"
+   "Respect Owner," "Confirm Destructive Action").
+3. Reviews `product/VISION.md` → sees product narrative combining
+   technical rigor with human-centered design.
 
-**Success:** Reviewer sees evidence of intentional design thinking paired
-with technical execution.
+**Success:** Reviewer sees evidence of intentional design thinking
+paired with technical execution — not just CRUD screens, but a system
+that treats users with care.


### PR DESCRIPTION
Milestones exist on GitHub but no stakeholder path leads to them.
This PR wires milestone awareness into every evaluator-facing surface.

## Changes

**README.md**
- Current Status section now shows milestone progress table instead of sprint history
- Links to milestone tracker, sprint board, and CHANGELOG

**docs/README.md**
- New Roadmap section explaining milestone-driven progress tracking
- Link to GitHub Milestones page

**portfolio/USE-CASES.md** (full rewrite)
- Fixed 4 dead links: \\docs/architecture/\\ → \\docs/adr/\\, \\docs/backlog/\\ → \\product/stories/\\
- Removed references to retired YAML planning system
- Removed references to directories that don't exist (\\portfolio/case-studies/\\, \\portfolio/demos/\\, \\portfolio/screenshots/\\, \\portfolio/presentations/\\)
- All 4 evaluator flows now navigate through milestones
- UC-03 now highlights sprint vs milestone distinction as a process signal

**portfolio/SURFACING-STRATEGY.md** (rewrite)
- Organized around milestone-driven narrative instead of sprint cadence
- Added milestone table showing what evaluators see at each stage
- Updated channel map to surface milestone progress
- Maintenance cadence now uses milestone completion as a trigger for demos and case studies
- Added anti-pattern: sprint-centric communication