### PR TITLE
docs: convert file path references to clickable links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,25 @@ camp-fit-fur-dogs/
 ## Key Documentation
 
 ### Product
-- **Product Vision** — `product/VISION.md`
-- **Product Backlog (Stories)** — `product/stories/`
-- **Emotional Guarantees** — `product/emotional-guarantees/`
-- **Definition of Ready** — `product/definition-of-ready/`
+- **Product Vision** — [`product/VISION.md`](product/VISION.md)
+- **Product Backlog (Stories)** — [`product/stories/`](product/stories/)
+- **Emotional Guarantees** — [`product/emotional-guarantees/`](product/emotional-guarantees/)
+- **Definition of Ready** — [`product/definition-of-ready/`](product/definition-of-ready/)
 
 ### Architecture & Governance
-- **ADRs** — `docs/adr/` (10 accepted decisions)
-- **Governance Model** — `docs/governance/governance.md`
-- **Sprint Reviews** — `docs/sprint-reviews/`
+- **ADRs** — [`docs/adr/`](docs/adr/) (10 accepted decisions)
+- **Governance Model** — [`docs/governance/governance.md`](docs/governance/governance.md)
+- **Sprint Reviews** — [`docs/sprint-reviews/`](docs/sprint-reviews/)
 
 ### Developer Experience
-- **Contributing Guide** — `CONTRIBUTING.md`
-- **Runbooks** — `docs/runbooks/`
-- **Documentation Hub** — `docs/README.md`
+- **Contributing Guide** — [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **Runbooks** — [`docs/runbooks/`](docs/runbooks/)
+- **Documentation Hub** — [`docs/README.md`](docs/README.md)
 
 ### Portfolio (Employer-Facing)
-- **Stakeholder Definition** — `portfolio/STAKEHOLDER.md`
-- **Use Cases** — `portfolio/USE-CASES.md`
-- **Surfacing Strategy** — `portfolio/SURFACING-STRATEGY.md`
+- **Stakeholder Definition** — [`portfolio/STAKEHOLDER.md`](portfolio/STAKEHOLDER.md)
+- **Use Cases** — [`portfolio/USE-CASES.md`](portfolio/USE-CASES.md)
+- **Surfacing Strategy** — [`portfolio/SURFACING-STRATEGY.md`](portfolio/SURFACING-STRATEGY.md)
 
 ---
 
@@ -142,8 +142,7 @@ This repository demonstrates:
 
 ## Sprint Board
 
-GitHub Projects Sprint Board:
-https://github.com/frankjhughes/camp-fit-fur-dogs/projects/14
+[GitHub Projects Sprint Board](https://github.com/frankjhughes/camp-fit-fur-dogs/projects/14)
 
 ---
 
@@ -174,9 +173,9 @@ Customer features are unblocked.
 
 | Milestone | Goal | Stories | Status |
 |-----------|------|---------|--------|
-| [M1: First Customer Vertical](../../milestones) | Create account, register dog, view profile | 3 | Not started |
-| [M2: Complete Dog Management](../../milestones) | Full dog CRUD with graceful edge cases | 7 | Not started |
-| [M3: Portfolio Showcase](../../milestones) | Docs, tooling, onboarding ready for review | 4 | Not started |
+| [M1: First Customer Vertical](https://github.com/frankjhughes/camp-fit-fur-dogs/milestones) | Create account, register dog, view profile | 3 | Not started |
+| [M2: Complete Dog Management](https://github.com/frankjhughes/camp-fit-fur-dogs/milestones) | Full dog CRUD with graceful edge cases | 7 | Not started |
+| [M3: Portfolio Showcase](https://github.com/frankjhughes/camp-fit-fur-dogs/milestones) | Docs, tooling, onboarding ready for review | 4 | Not started |
 
 **22 stories remaining** across 3 milestones | **17 completed** | **10 ADRs** | Next story: US-045
 

--- a/portfolio/SURFACING-STRATEGY.md
+++ b/portfolio/SURFACING-STRATEGY.md
@@ -8,7 +8,7 @@
 ## Principles
 
 1. **Zero-hop discoverability** — every key artifact is reachable from
-   the repo root `README.md` within one click.
+   the repo root [`README.md`](../README.md) within one click.
 2. **Layered depth** — surface a summary first, link to detail second.
    Respect evaluator time.
 3. **Living proof** — link to the actual milestone tracker, CI runs, and
@@ -24,10 +24,10 @@ Each milestone unlocks a new level of demonstrable capability:
 
 | Milestone | What an Evaluator Sees | Key Artifacts |
 |-----------|----------------------|---------------|
-| M0 (done) | Engineering foundation, architecture, CI, governance | `docs/adr/`, `.github/workflows/`, `CONTRIBUTING.md` |
-| M1 | First working feature end-to-end through DDD layers | `src/`, domain tests, API endpoints |
+| M0 (done) | Engineering foundation, architecture, CI, governance | [`docs/adr/`](../docs/adr/), [`.github/workflows/`](../.github/workflows/), [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+| M1 | First working feature end-to-end through DDD layers | [`src/`](../src/), domain tests, API endpoints |
 | M2 | Product maturity — edge cases handled with emotional safety | Product stories, sprint reviews, test coverage |
-| M3 | Fully documented, tooled, onboardable project | `docs/runbooks/`, developer guide, scaffold tool |
+| M3 | Fully documented, tooled, onboardable project | [`docs/runbooks/`](../docs/runbooks/), developer guide, scaffold tool |
 
 The milestone tracker is the single source of truth for project progress:
 https://github.com/frankjhughes/camp-fit-fur-dogs/milestones
@@ -38,22 +38,22 @@ https://github.com/frankjhughes/camp-fit-fur-dogs/milestones
 
 | Channel | What to Surface | Link Target |
 |---------|----------------|-------------|
-| Repo root `README.md` | Milestone progress table, architecture summary | Milestone tracker, `portfolio/README.md` |
+| Repo root [`README.md`](../README.md) | Milestone progress table, architecture summary | Milestone tracker, [`portfolio/README.md`](README.md) |
 | LinkedIn Featured section | Repo link with milestone status callout | Repo root |
 | Resume / CV | Repo URL + current milestone + one-line description | Repo root |
 | GitHub Profile README | Pinned repo with descriptive tagline | Repo root |
-| Portfolio website (future) | Embedded milestone progress, case study pages | Milestone tracker, `portfolio/` |
+| Portfolio website (future) | Embedded milestone progress, case study pages | Milestone tracker, [`portfolio/`](.) |
 
 ---
 
 ## Repo Root README Additions
 
-The repo root `README.md` includes:
+The repo root [`README.md`](../README.md) includes:
 
 - **Milestone Progress** table with links to GitHub Milestones
-- **Sprint History** link to `CHANGELOG.md`
+- **Sprint History** link to [`CHANGELOG.md`](../CHANGELOG.md)
 - **Sprint Board** link to GitHub Projects
-- **Portfolio** section linking to `portfolio/README.md`
+- **Portfolio** section linking to [`portfolio/README.md`](README.md)
 
 ---
 
@@ -73,8 +73,8 @@ The repo root `README.md` includes:
 ## Anti-Patterns to Avoid
 
 - **Dead links** — CI should lint internal markdown links.
-- **Orphaned artifacts** — every file in `portfolio/` must be linked from
-  the portfolio `README.md`.
+- **Orphaned artifacts** — every file in [`portfolio/`](.) must be linked from
+  the portfolio [`README.md`](../README.md).
 - **Sprint-centric communication** — stakeholders care about capability
   milestones ("can it register a dog?"), not timeboxes ("Sprint 3 ended").
 - **Stale milestone counts** — README status section must stay current

--- a/portfolio/USE-CASES.md
+++ b/portfolio/USE-CASES.md
@@ -12,13 +12,13 @@
 **Trigger:** Clicks GitHub link on resume or LinkedIn.
 
 **Flow:**
-1. Lands on repo root → reads `README.md` — project summary, milestone
+1. Lands on repo root → reads [`README.md`](../README.md) — project summary, milestone
    progress table, and engineering practices overview.
 2. Sees milestone tracker link → clicks through to GitHub Milestones page
    → sees progress bars for M1, M2, M3.
-3. Navigates to `portfolio/README.md` → sees curated index of
+3. Navigates to [`portfolio/README.md`](README.md) → sees curated index of
    portfolio-relevant artifacts.
-4. Reviews `product/VISION.md` → understands product thinking and
+4. Reviews [`product/VISION.md`](../product/VISION.md) → understands product thinking and
    emotional safety commitments.
 
 **Success:** Manager understands scope, quality bar, and Frank's role
@@ -34,13 +34,13 @@ advancing, not abandoned.
 **Trigger:** Asked to evaluate candidate's technical ability.
 
 **Flow:**
-1. Opens `docs/adr/` → reviews 10 Architecture Decision Records covering
+1. Opens [`docs/adr/`](../docs/adr/) → reviews 10 Architecture Decision Records covering
    DDD layers, DX toolchain, infrastructure, and governance choices.
-2. Inspects `src/` → sees clean DDD layer separation (Api, Application,
+2. Inspects [`src/`](../src/) → sees clean DDD layer separation (Api, Application,
    Domain, Infrastructure, SharedKernel).
 3. Opens milestone M1 on GitHub → sees which stories are in progress and
    how domain aggregates map to customer-facing features.
-4. Inspects CI/CD pipeline (`.github/workflows/ci.yaml`) → confirms
+4. Inspects CI/CD pipeline ([`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml)) → confirms
    deterministic builds and test gates.
 5. Reads recent PRs → evaluates commit hygiene, PR descriptions, and
    branch discipline.
@@ -58,16 +58,16 @@ a scaffold.
 **Trigger:** Interview prep or async evaluation.
 
 **Flow:**
-1. Opens `product/stories/` → reviews story-first markdown backlog,
+1. Opens [`product/stories/`](../product/stories/) → reviews story-first markdown backlog,
    capability themes, and emotional safety guarantees.
 2. Opens milestone tracker → sees how 22 remaining stories are organized
    into three capability milestones (not just sprints).
 3. Opens GitHub Projects board → sees sprint cadence and issue lifecycle.
-4. Opens `docs/governance/governance.md` → reads living governance
+4. Opens [`docs/governance/governance.md`](../docs/governance/governance.md) → reads living governance
    document with versioned process decisions.
-5. Opens `CONTRIBUTING.md` → sees 2-step story workflow (story file as
+5. Opens [`CONTRIBUTING.md`](../CONTRIBUTING.md) → sees 2-step story workflow (story file as
    backlog, issue as sprint commitment).
-6. Opens `docs/sprint-reviews/sprint-2.md` → sees structured retro with
+6. Opens [`docs/sprint-reviews/sprint-2.md`](../docs/sprint-reviews/sprint-2.md) → sees structured retro with
    honest "what could improve" section.
 
 **Success:** Interviewer validates Agile fluency, stakeholder empathy,
@@ -83,12 +83,12 @@ capability goals (milestones).
 **Trigger:** Portfolio review for hybrid roles.
 
 **Flow:**
-1. Opens `product/emotional-guarantees/` → sees design principles that
+1. Opens [`product/emotional-guarantees/`](../product/emotional-guarantees/) → sees design principles that
    prioritize user emotional safety alongside functionality.
 2. Reviews milestone M2 stories → sees edge case handling driven by
    empathy, not just requirements (e.g., "Reassurance on Failure,"
    "Respect Owner," "Confirm Destructive Action").
-3. Reviews `product/VISION.md` → sees product narrative combining
+3. Reviews [`product/VISION.md`](../product/VISION.md) → sees product narrative combining
    technical rigor with human-centered design.
 
 **Success:** Reviewer sees evidence of intentional design thinking


### PR DESCRIPTION
Every backtick path reference in stakeholder-facing docs is now a
clickable link on GitHub. No more dead strings — evaluators can click
through the repo without copy-pasting paths into the address bar.

## Files Changed

**README.md**
- 13 file/folder paths in Key Documentation section converted to relative links
- Fixed 3 broken milestone links (`../../milestones` → absolute GitHub URL)
- Sprint Board bare URL converted to markdown link

**portfolio/USE-CASES.md**
- 11 paths across all 4 evaluator use case flows converted to relative links
- All paths use correct `../` prefix (file lives in `portfolio/`)

**portfolio/SURFACING-STRATEGY.md**
- 10 paths across tables and prose converted to relative links
- All paths use correct `../` prefix

## Not Changed
- `CHANGELOG.md` — historical record, paths reference deleted content
- `CONTRIBUTING.md` — only path is a template pattern (`US-NNN-title.md`)
- `docs/README.md` — already uses proper markdown links