### PR TITLE
stories: add US-045 and US-046 workflow guide stories

### DIFF
--- a/product/stories/docs/US-045-product-owner-workflow-guide.md
+++ b/product/stories/docs/US-045-product-owner-workflow-guide.md
@@ -1,0 +1,88 @@
+# US-045 — Product Owner Workflow Guide
+
+## User Story
+
+As a product owner joining the project, I want a single guide
+that documents how to write stories, manage the backlog, apply
+emotional guarantees, and run refinement — so that product
+decisions follow a consistent, repeatable process without
+tribal knowledge.
+
+## Context
+
+The project uses a story-first approach where markdown files in
+`product/stories/` are the single source of truth for the backlog.
+Stories follow naming conventions (ADR-0009), tag emotional
+guarantees, and must pass the definition of ready before sprint
+commitment. No documentation currently explains this workflow
+end-to-end.
+
+US-010 (PO Contributor Guide) was absorbed into US-022 during
+Sprint 2, but US-022 focused on the planning runbook — the
+standalone PO workflow guide was never produced.
+
+## Scope
+
+This guide lives at `docs/guides/product-owner-guide.md` and is
+linked from the CONTRIBUTING.md role-routing hub (created by US-009).
+
+## Acceptance Criteria
+
+### Story Authoring
+
+- [ ] Story file format documented: heading, user story,
+      value/context, acceptance criteria, emotional guarantees,
+      dependencies, open questions.
+- [ ] Story naming convention explained with examples
+      (ADR-0009: `US-NNN-kebab-title.md`).
+- [ ] Domain directory structure explained
+      (`product/stories/customer/`, `docs/`, `infra/`).
+- [ ] Acceptance criteria writing guidelines: observable, testable,
+      no implementation details.
+
+### Backlog Management
+
+- [ ] How to add a new story to the backlog (create file, choose
+      domain directory, next available US number).
+- [ ] How to retire, absorb, or split stories — with examples
+      from project history.
+- [ ] How to update story scope after refinement — what changes
+      are acceptable vs requiring a new story.
+
+### Emotional Guarantees
+
+- [ ] Full list of emotional guarantees (EG-01 through EG-07)
+      with descriptions and examples.
+- [ ] How to tag stories with relevant guarantees.
+- [ ] How emotional guarantees become acceptance criteria on
+      feature stories (DoD integration).
+
+### Definition of Ready
+
+- [ ] All 8 DoR criteria listed and explained with pass/fail
+      examples.
+- [ ] How to run a readiness check before sprint planning.
+
+### Refinement and Prioritization
+
+- [ ] When and how to run backlog refinement.
+- [ ] How to identify stories that need grooming (scope unclear,
+      missing AC, stale dependencies).
+- [ ] How milestones inform prioritization — capability goals
+      vs sprint timeboxes.
+
+### Milestones
+
+- [ ] Difference between milestones and sprints explained.
+- [ ] How to assign stories to milestones.
+- [ ] How to propose new milestones or reorganize existing ones.
+
+## Dependencies
+
+- US-009 (Developer Contributor Guide) creates the CONTRIBUTING.md
+  hub that routes to this guide.
+
+## Open Questions
+
+- Should the guide include a decision flowchart for story splitting?
+- Should refinement checklists be a separate runbook or inline?

--- a/product/stories/docs/US-046-scrum-master-workflow-guide.md
+++ b/product/stories/docs/US-046-scrum-master-workflow-guide.md
@@ -1,0 +1,86 @@
+# US-046 — Scrum Master Workflow Guide
+
+## User Story
+
+As a scrum master joining the project, I want a single guide
+that documents how to run sprint ceremonies, manage the board,
+create issues from stories, and maintain project artifacts — so
+that sprint execution follows a consistent, transparent process.
+
+## Context
+
+The project uses a 2-step workflow: story files are the backlog,
+GitHub Issues are created only when stories are pulled into a
+sprint. Sprint tracking uses labels (`sprint:N`) while capability
+progress uses GitHub Milestones (M1, M2, M3). No documentation
+currently explains this workflow or the ceremony cadence.
+
+US-011 (SM Contributor Guide) was absorbed into US-022 during
+Sprint 2, but US-022 focused on the planning runbook — the
+standalone SM workflow guide was never produced.
+
+## Scope
+
+This guide lives at `docs/guides/scrum-master-guide.md` and is
+linked from the CONTRIBUTING.md role-routing hub (created by US-009).
+
+## Acceptance Criteria
+
+### Sprint Planning
+
+- [ ] How to select stories from the backlog for sprint commitment.
+- [ ] How to create GitHub Issues from story files (2-step workflow
+      documented with exact commands).
+- [ ] How to assign milestone and sprint label to each issue.
+- [ ] How to set a sprint goal that connects to milestone objectives.
+- [ ] Sprint capacity considerations documented.
+
+### Board Management
+
+- [ ] GitHub Projects board setup and column structure explained.
+- [ ] How to move issues through the board during a sprint.
+- [ ] How to handle blocked issues and dependencies.
+- [ ] How to track sprint progress against the sprint goal.
+
+### Sprint Review
+
+- [ ] Sprint review document format explained with reference to
+      template (`docs/sprint-reviews/template.md`).
+- [ ] How to compile shipped stories, key decisions, metrics,
+      and retro items.
+- [ ] How to update CHANGELOG.md after each merged PR.
+- [ ] How to update README milestone progress after sprint review.
+
+### Sprint Retrospective
+
+- [ ] Retro format documented: what went well, what could improve,
+      action items.
+- [ ] How action items feed into next sprint planning.
+
+### Milestone Management
+
+- [ ] Difference between milestones (capability goals) and sprints
+      (timeboxes) explained.
+- [ ] How to create, close, and update GitHub Milestones.
+- [ ] When to record demos or case studies (milestone completion
+      triggers).
+- [ ] How to update milestone progress in stakeholder artifacts.
+
+### Merge Governance
+
+- [ ] Branch protection rules explained (who can merge, required
+      reviews).
+- [ ] CODEOWNERS file explained.
+- [ ] PR checklist walkthrough.
+- [ ] How to handle stale branches and failed PRs.
+
+## Dependencies
+
+- US-009 (Developer Contributor Guide) creates the CONTRIBUTING.md
+  hub that routes to this guide.
+
+## Open Questions
+
+- Should the guide include a sprint planning checklist as a
+  separate artifact?
+- Should CHANGELOG maintenance be automated via CI?


### PR DESCRIPTION
Adds two new stories to the backlog for Sprint 3 commitment.

## New Stories

**US-045 — Product Owner Workflow Guide** (16 AC)
- Story authoring format, naming convention, domain directories
- Backlog management (add, retire, absorb, split)
- Emotional guarantees tagging and DoD integration
- Definition of ready criteria with examples
- Refinement workflow and milestone-driven prioritization

**US-046 — Scrum Master Workflow Guide** (17 AC)
- Sprint planning and 2-step issue creation workflow
- Board management and progress tracking
- Sprint review/retro documentation
- Milestone management (milestones vs sprints)
- Merge governance and branch protection

## Why New Stories

US-010 (PO Guide) and US-011 (SM Guide) were absorbed into US-022
during Sprint 2, but US-022 was the Planning Runbook — it never
produced the standalone guide documents. These stories restore
that scope with AC informed by the actual workflows we now use.