### PR TITLE
docs: add contributor workflow guides (US-009, US-045, US-046)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,76 +1,47 @@
 # Contributing to Camp Fit Fur Dogs
 
-Thanks for contributing! This guide keeps our workflow consistent and our history clean.
+Welcome! This project uses role-based contributor guides. Find yours
+below and you'll have everything you need to start contributing.
 
----
+## Choose Your Role
 
-## Branch Naming
+### 🛠️ [Developer Guide](docs/guides/developer-guide.md)
 
-| Type | Pattern | Example |
-|------|---------|---------|
-| Feature | `feature/<story-slug>` | `feature/ci-baseline-build-and-test` |
-| Bug fix | `fix/<description>` | `fix/test-runner-timeout` |
-| Docs | `docs/<description>` | `docs/contributing-and-pr-template` |
-| Chore | `chore/<description>` | `chore/planning-timestamps` |
+Clone the repo, build the app, write code, and ship PRs.
 
-Always branch from `main`. Keep branch names lowercase, kebab-case.
+Covers: prerequisites, project structure, architecture, branch
+workflow, testing, PR process, and ADRs.
 
----
+### 📋 [Product Owner Guide](docs/guides/product-owner-guide.md)
 
-## Commit Messages
+Write stories, manage the backlog, apply emotional guarantees, and
+run refinement.
 
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
+Covers: story authoring format, naming conventions, acceptance
+criteria, emotional guarantees, Definition of Ready, backlog
+management, and milestone prioritization.
 
-```
-<type>: <short summary>
+### 🏃 [Scrum Master Guide](docs/guides/scrum-master-guide.md)
 
-<optional body � what and why, not how>
-```
+Run sprint ceremonies, manage the board, create issues from stories,
+and maintain project artifacts.
 
-### Types
+Covers: sprint planning, 2-step issue workflow, board management,
+sprint review/retro, milestone management, and merge governance.
 
-| Type | When |
-|------|------|
-| `feat` | New functionality |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
-| `chore` | Tooling, config, maintenance |
-| `test` | Adding or updating tests |
-| `refactor` | Code change that neither fixes nor adds |
+## Quick Links
 
-### Rules
+| Resource | Location |
+|----------|----------|
+| Backlog (story files) | [`product/stories/`](product/stories/) |
+| Definition of Ready | [`product/definition-of-ready/`](product/definition-of-ready/) |
+| Emotional Guarantees | [`product/emotional-guarantees/`](product/emotional-guarantees/) |
+| Architecture Decisions | [`docs/adr/`](docs/adr/) |
+| Sprint Reviews | [`docs/sprint-reviews/`](docs/sprint-reviews/) |
+| Governance | [`docs/governance/`](docs/governance/) |
+| Project Board | [GitHub Projects](https://github.com/users/frankjhughes/projects/14) |
 
-- Subject line: imperative mood, no period, = 72 characters
-- Body: wrap at 72 characters, explain *what* and *why*
-- Reference the issue: `Closes #N` in the PR body, not the commit
+## Code of Conduct
 
----
-
-## Pull Request Workflow
-
-1. **One story = one PR.** Don't bundle unrelated changes.
-2. **Fill out the PR template.** Every section exists for a reason.
-3. **Self-review before requesting review.** Read the diff as if you didn't write it.
-4. **Squash-merge into `main`.** Keep the history linear.
-5. **Delete the branch after merge.**
-
----
-
-## Definition of Done
-
-A story is done when:
-
-- [ ] Code compiles with zero warnings
-- [ ] All tests pass
-- [ ] PR template is filled out completely
-- [ ] PR is squash-merged into `main`
-- [ ] CI badge is green
-
----
-
-## Story Workflow
-
-1. Write `product/stories/<domain>/US-NNN-title.md` — commit via PR.
-2. Run: `gh issue create --title "US-NNN: Title" --milestone "Sprint N" --body "See product/stories/..."`
-
-The product story is the spec. The GitHub Issue is the tracker. The board auto-populates.
+Be kind. Be constructive. Assume good intent. Every contributor —
+regardless of experience level — deserves respect and clear feedback.

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -1,0 +1,236 @@
+# Developer Contributor Guide
+
+Welcome to Camp Fit Fur Dogs. This guide covers everything you need to
+clone the repo, run the app locally, and ship code through our pull
+request workflow.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| .NET SDK | 9.0+ | Build and run the API |
+| Docker Desktop | Latest | Container runtime for local services |
+| PowerShell | 7+ | Developer experience scripts |
+| Git | 2.x | Source control |
+| GitHub CLI (`gh`) | 2.x | Issue and PR management |
+
+## Getting Started
+
+```powershell
+# Clone the repo
+git clone https://github.com/frankjhughes/camp-fit-fur-dogs.git
+cd camp-fit-fur-dogs
+
+# Bootstrap the local environment
+./dx.ps1 bootstrap
+
+# Start the app
+./dx.ps1 up
+```
+
+The `dx.ps1` script is the single entry point for all developer
+commands. Run `./dx.ps1 help` to see available commands.
+
+## Project Structure
+
+```
+camp-fit-fur-dogs/
+├── src/
+│   ├── CampFitFurDogs.Api/           # ASP.NET Core host, controllers, middleware
+│   ├── CampFitFurDogs.Application/   # Use cases, command/query handlers
+│   ├── CampFitFurDogs.Domain/        # Aggregates, entities, value objects, domain events
+│   └── CampFitFurDogs.Infrastructure/# EF Core, repos, external service adapters
+├── tests/
+│   ├── CampFitFurDogs.Domain.Tests/
+│   └── CampFitFurDogs.Api.Tests/
+├── product/
+│   ├── stories/                      # Backlog (the source of truth)
+│   ├── definition-of-ready/
+│   └── emotional-guarantees/
+├── docs/
+│   ├── adr/                          # Architecture Decision Records
+│   ├── sprint-reviews/               # Sprint review documents
+│   ├── governance/                   # Process governance
+│   └── guides/                       # ← You are here
+├── CONTRIBUTING.md                   # Role-routing hub
+├── CODEOWNERS                        # PR review assignments
+├── CHANGELOG.md                      # Release history
+└── dx.ps1                            # Developer experience script
+```
+
+## Architecture
+
+The codebase follows Domain-Driven Design with four layers. Dependencies
+point inward — Domain has zero external references.
+
+```
+Api → Application → Domain
+ └→ Infrastructure → Domain
+```
+
+- **Domain** — aggregates, value objects, domain events, repository
+  interfaces. No framework dependencies.
+- **Application** — command and query handlers that orchestrate domain
+  logic. References Domain only.
+- **Infrastructure** — EF Core DbContext, repository implementations,
+  external adapters. References Domain for interface contracts.
+- **Api** — ASP.NET Core host, controllers, middleware, DI composition
+  root. References all layers.
+
+### Key conventions
+
+- One aggregate per file, named after the aggregate root.
+- Value objects are `record` types in the aggregate's namespace.
+- Repository interfaces live in Domain; implementations in
+  Infrastructure.
+- No reflection, no magic strings — explicit, compile-time-safe
+  bindings.
+
+## Development Workflow
+
+### Branch naming
+
+```
+<type>/<short-description>
+```
+
+| Type | When |
+|------|------|
+| `feature/` | New user-facing capability |
+| `fix/` | Bug fix |
+| `docs/` | Documentation only |
+| `infra/` | CI/CD, tooling, config |
+| `refactor/` | Internal restructuring |
+
+Examples: `feature/us-027-create-customer-account`,
+`docs/sprint-3-stories`, `infra/ci-pipeline`.
+
+### Commit messages
+
+Use conventional-style commits:
+
+```
+<type>: <short summary>
+
+<optional body explaining why, not what>
+```
+
+Types match branch types: `feature`, `fix`, `docs`, `infra`,
+`refactor`.
+
+### Development loop
+
+1. Pull latest `main`.
+2. Create a feature branch from `main`.
+3. Make small, focused commits.
+4. Push and open a PR against `main`.
+5. Address CODEOWNERS review feedback.
+6. Squash-merge after approval.
+
+## Building and Running
+
+```powershell
+# Full build
+./dx.ps1 build
+
+# Run the API (with hot reload)
+./dx.ps1 up
+
+# Run all tests
+./dx.ps1 test
+
+# Tear down local containers
+./dx.ps1 down
+
+# Reset local database
+./dx.ps1 db-reset
+```
+
+## Testing
+
+- **Domain tests** — pure unit tests, no mocks, no infrastructure.
+  Test aggregate behavior and value object invariants.
+- **API tests** — integration tests using `WebApplicationFactory`.
+  Test HTTP endpoints against a real test database.
+
+Name test methods to describe the scenario:
+`CreateAccount_WithDuplicateEmail_ReturnsConflict`.
+
+Run tests before pushing:
+
+```powershell
+./dx.ps1 test
+```
+
+## Pull Request Process
+
+### Opening a PR
+
+1. Push your branch to origin.
+2. Open a PR against `main` using `gh pr create`.
+3. Title format: `<type>: <summary>` (matches commit convention).
+4. Body should reference the story: `Closes #<issue-number>`.
+5. CODEOWNERS will be auto-assigned as reviewers.
+
+### PR checklist
+
+Before requesting review, confirm:
+
+- [ ] Code compiles with zero warnings.
+- [ ] All tests pass locally (`./dx.ps1 test`).
+- [ ] New code has tests covering the happy path and key edge cases.
+- [ ] No unrelated changes bundled into the PR.
+- [ ] Commit history is clean (squash fixups before review).
+
+### Merge rules
+
+- PRs require at least one CODEOWNERS approval.
+- All CI checks must pass.
+- Squash-merge is the default strategy.
+- Delete the branch after merge.
+
+## Architecture Decision Records (ADRs)
+
+Significant technical decisions are recorded as ADRs in `docs/adr/`.
+
+### When to write an ADR
+
+- Choosing a framework, library, or tool.
+- Changing project structure or conventions.
+- Making a trade-off that future contributors will question.
+
+### ADR format
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+Accepted | Superseded | Deprecated
+
+## Context
+What situation prompted this decision?
+
+## Decision
+What did we decide?
+
+## Consequences
+What trade-offs result from this decision?
+```
+
+### Existing ADRs
+
+Browse the full list at [`docs/adr/`](../../docs/adr/).
+
+## Code of Conduct
+
+Be kind. Be constructive. Assume good intent. Every contributor —
+regardless of experience level — deserves respect and clear feedback.
+
+## Getting Help
+
+- Open a GitHub Discussion for questions.
+- Tag `@FrankJHughes` for architecture or process questions.
+- Check the [Product Owner Guide](product-owner-guide.md) for story
+  and backlog questions.
+- Check the [Scrum Master Guide](scrum-master-guide.md) for sprint
+  and board questions.

--- a/docs/guides/product-owner-guide.md
+++ b/docs/guides/product-owner-guide.md
@@ -1,0 +1,325 @@
+# Product Owner Workflow Guide
+
+This guide documents how to write stories, manage the backlog, apply
+emotional guarantees, and run refinement for Camp Fit Fur Dogs.
+
+## How the Backlog Works
+
+The backlog is **markdown files in Git**, not a tool. Every story lives
+in `product/stories/` under a domain directory. GitHub Issues are only
+created when a story is pulled into a sprint — they are sprint
+commitments, not backlog items.
+
+```
+product/stories/
+├── customer/    # End-user-facing features (accounts, dogs, bookings)
+├── docs/        # Documentation and contributor guides
+└── infra/       # CI/CD, tooling, developer experience
+```
+
+This means the backlog is versioned, reviewable, and searchable with
+standard Git tools. No story is lost, renamed, or silently edited
+without a commit trail.
+
+## Story Authoring
+
+### File naming convention (ADR-0009)
+
+```
+US-NNN-kebab-case-title.md
+```
+
+- **US** — User Story prefix (always uppercase).
+- **NNN** — Three-digit number, zero-padded, globally unique across all
+  domains. Assign the next available number.
+- **kebab-case-title** — Lowercase, hyphen-separated summary matching
+  the story heading.
+
+Examples:
+- `US-027-create-customer-account.md`
+- `US-045-product-owner-workflow-guide.md`
+
+### Story format
+
+Stories use one of two templates depending on the domain:
+
+**Customer stories** (features):
+
+```markdown
+# US-NNN — Title
+
+## Intent
+
+As a [role], I want [capability], so that [value].
+
+## Value
+
+Why this matters to the user and the product.
+
+## Acceptance Criteria
+
+- [ ] Observable, testable criterion 1.
+- [ ] Observable, testable criterion 2.
+
+## Emotional Guarantees
+
+- **EG-NN Name** — How this story honors the guarantee.
+
+## Edge Cases
+
+- What happens when [boundary condition]?
+
+## Notes
+
+Optional context, links, or prior art.
+```
+
+**Docs / infra stories**:
+
+```markdown
+# US-NNN — Title
+
+## User Story
+
+As a [role], I want [capability], so that [value].
+
+## Context
+
+Background, motivation, and prior decisions that inform this work.
+
+## Scope
+
+What this story produces and where it lives.
+
+## Acceptance Criteria
+
+### Section Name
+
+- [ ] Criterion grouped by deliverable section.
+
+## Dependencies
+
+- Other stories this depends on.
+
+## Open Questions
+
+- Unresolved decisions to address during refinement.
+```
+
+### Writing good acceptance criteria
+
+Each criterion must be:
+
+- **Observable** — A reviewer can see whether it's done.
+- **Testable** — You can write a pass/fail check.
+- **Implementation-free** — Describe *what*, never *how*.
+
+| Good | Bad |
+|------|-----|
+| Customer sees a confirmation message after registration. | Use a toast notification component. |
+| Duplicate email returns a clear error. | Add a unique constraint on the email column. |
+| Guide includes a branch naming table. | Write the table in HTML. |
+
+## Emotional Guarantees
+
+Emotional guarantees are promises the product makes to every user. They
+are not features — they are constraints that shape how features behave.
+
+| ID | Name | Promise |
+|----|------|---------|
+| EG-01 | Calm Confidence | The interface never creates anxiety or urgency. |
+| EG-02 | Respected Identity | Personal information is handled with care and never exposed carelessly. |
+| EG-03 | Graceful Recovery | Errors are explained clearly with a path forward. |
+| EG-04 | Forgiveness | The system is forgiving of interruption — work is never silently lost. |
+| EG-05 | Joyful Moments | Positive interactions include small moments of warmth. |
+| EG-06 | Transparent Progress | The user always knows where they are and what comes next. |
+| EG-07 | Inclusive Access | The experience works for all users regardless of ability. |
+
+### Tagging stories with emotional guarantees
+
+Every customer story must reference at least one emotional guarantee.
+In the `## Emotional Guarantees` section, list each relevant guarantee
+and explain how the story honors it:
+
+```markdown
+## Emotional Guarantees
+
+- **EG-01 Calm Confidence** — Registration flow uses no countdown
+  timers or "limited availability" language.
+- **EG-03 Graceful Recovery** — Validation errors appear inline next
+  to the field, with a suggestion for correction.
+```
+
+Emotional guarantees become acceptance criteria. If a story tags EG-03,
+then graceful error handling is testable scope — not aspirational.
+
+## Definition of Ready
+
+Before a story can be pulled into a sprint, it must pass all 8 criteria:
+
+| # | Criterion | What to check |
+|---|-----------|---------------|
+| 1 | Intent is clear | The "As a / I want / So that" is specific and unambiguous. |
+| 2 | Single capability | The story delivers one thing. If you say "and" in the title, consider splitting. |
+| 3 | Emotional guarantees tagged | At least one EG is referenced with a concrete explanation. |
+| 4 | Acceptance criteria are observable | Every AC can be verified by a reviewer without reading code. |
+| 5 | Edge cases acknowledged | Boundary conditions are listed, even if the AC says "handled gracefully." |
+| 6 | Scope is contained | The story doesn't require work outside its domain directory. |
+| 7 | Dependencies are identified | Blocking stories or technical prerequisites are listed. |
+| 8 | No implementation prescribed | AC describe behavior, not technology choices. |
+
+### Running a readiness check
+
+Before sprint planning, review each candidate story against the 8
+criteria. If a story fails any criterion, it goes back to refinement —
+not into the sprint.
+
+**Pass example** — US-027 (Create Customer Account):
+- Intent: clear (customer creates account).
+- Single capability: yes (account creation only).
+- EGs: EG-01, EG-02, EG-03 all explained.
+- AC: 5 observable criteria.
+- Edge cases: duplicate account documented.
+- Scope: contained to customer domain.
+- Dependencies: none.
+- Implementation: no tech prescribed.
+
+**Fail example** — A story titled "Build the dog management system":
+- Fails criterion 2 (multiple capabilities bundled).
+- Fails criterion 6 (scope spans multiple aggregates).
+- Action: split into register, edit, view, delete stories.
+
+## Backlog Management
+
+### Adding a new story
+
+1. Determine the domain directory (`customer/`, `docs/`, or `infra/`).
+2. Find the next available US number by checking all directories.
+3. Create the file using the appropriate template.
+4. Open a PR to `main` with the story file.
+
+### Retiring a story
+
+When a story is no longer relevant:
+
+1. Delete the story file.
+2. Commit with message: `stories: retire US-NNN (reason)`.
+3. If the story was referenced by other stories, update their
+   dependency sections.
+
+### Absorbing a story
+
+When one story's scope is fully covered by another:
+
+1. Add a note at the top of the absorbed story:
+   `> Absorbed into US-NNN. See [US-NNN](path).`
+2. Move any unique AC into the absorbing story.
+3. Do not delete — the absorbed file serves as a redirect.
+
+Project example: US-010 and US-011 were absorbed into US-022 during
+Sprint 2. The scope they covered (PO and SM guides) was later restored
+as US-045 and US-046 when the absorbing story didn't deliver the full
+scope.
+
+**Lesson:** Absorbing is not free. Track what scope the absorbed story
+carried and verify the absorbing story actually delivers it.
+
+### Splitting a story
+
+When a story is too large or covers multiple capabilities:
+
+1. Create new story files for each split.
+2. Add a note to the original:
+   `> Split into US-NNN and US-NNN.`
+3. Redistribute AC across the new stories.
+4. Each split story must independently pass the Definition of Ready.
+
+### Updating scope after refinement
+
+Acceptable changes to a committed story:
+
+- Clarifying AC wording (same intent, better precision).
+- Adding edge cases discovered during refinement.
+- Adding or updating EG explanations.
+
+Changes that require a new story:
+
+- Adding a new capability ("also add edit functionality").
+- Changing the user role or intent.
+- Doubling the AC count.
+
+## Refinement and Prioritization
+
+### When to refine
+
+- **Before sprint planning** — candidate stories for the next sprint
+  must pass the Definition of Ready.
+- **Mid-sprint** — when blocked work reveals missing AC or edge cases
+  on a future story.
+- **After retro** — when action items identify backlog gaps.
+
+### Identifying stories that need grooming
+
+Look for:
+
+- Stories with fewer than 3 AC (likely underspecified).
+- Stories with no emotional guarantees tagged.
+- Stories with open questions that haven't been answered.
+- Stories whose dependencies have changed since they were written.
+- Stories older than 2 sprints without being pulled (may be stale).
+
+### Milestone-driven prioritization
+
+Milestones define capability goals. Sprints are timeboxes. They are
+independent:
+
+- **Milestones** answer: *What must be true for this capability to
+  exist?*
+- **Sprints** answer: *What will we finish in the next timebox?*
+
+Prioritize by milestone:
+
+1. Which milestone is closest to completion?
+2. Which stories in that milestone are ready (pass DoR)?
+3. Do any ready stories unblock other milestone stories?
+
+Current milestones:
+
+| Milestone | Goal | Key Stories |
+|-----------|------|-------------|
+| M1: First Customer Vertical | Account + dog registration + profile view | US-027, US-028, US-029 |
+| M2: Complete Dog Management | Full CRUD + edge cases for dog records | US-030-034, US-037, US-044 |
+| M3: Portfolio Showcase | Project documented, tooled, and presentable | US-006, US-007, US-009, US-022 |
+
+## Milestones
+
+### Creating a new milestone
+
+A milestone is appropriate when:
+
+- Multiple stories contribute to a single capability goal.
+- The goal is demonstrable ("a customer can register and view a dog").
+- Completion is meaningful to stakeholders.
+
+To propose a milestone:
+
+1. Write a one-sentence goal.
+2. List the stories required to achieve it.
+3. Verify no story appears in two milestones.
+4. Create the GitHub Milestone with the goal as the description.
+
+### Reorganizing milestones
+
+When priorities shift:
+
+1. Move stories between milestones via `gh issue edit --milestone`.
+2. Update the milestone description if the goal changed.
+3. Document the change in the next sprint review.
+
+## Getting Help
+
+- Check the [Scrum Master Guide](scrum-master-guide.md) for sprint
+  ceremonies and board management.
+- Check the [Developer Guide](developer-guide.md) for code and PR
+  workflow.
+- Tag `@FrankJHughes` for backlog or prioritization questions.

--- a/docs/guides/scrum-master-guide.md
+++ b/docs/guides/scrum-master-guide.md
@@ -1,0 +1,368 @@
+# Scrum Master Workflow Guide
+
+This guide documents how to run sprint ceremonies, manage the board,
+create issues from stories, and maintain project artifacts for
+Camp Fit Fur Dogs.
+
+## Core Concept: The 2-Step Workflow
+
+This project separates the **backlog** from **sprint commitments**:
+
+| Artifact | Where | Purpose |
+|----------|-------|---------|
+| Story files | `product/stories/` | The backlog — all potential work |
+| GitHub Issues | `Issues` tab | Sprint commitments — only created when pulled into a sprint |
+
+**Stories are never pre-created as issues.** A GitHub Issue means "we
+committed to doing this in sprint N." This keeps the issue tracker
+clean and the board meaningful.
+
+## Sprint Planning
+
+### Step 1: Select stories
+
+1. Review candidate stories with the Product Owner.
+2. Verify each story passes all 8 Definition of Ready criteria
+   (see the [Product Owner Guide](product-owner-guide.md#definition-of-ready)).
+3. Agree on a sprint goal that connects to a milestone objective.
+4. Confirm the team has capacity for the selected stories.
+
+### Step 2: Create issues from stories
+
+For each committed story, create a GitHub Issue:
+
+```powershell
+$repo = "frankjhughes/camp-fit-fur-dogs"
+
+gh issue create --repo $repo `
+  --title "US-NNN: Story Title" `
+  --body "Story: [US-NNN](https://github.com/$repo/blob/main/product/stories/<domain>/US-NNN-kebab-title.md)" `
+  --milestone "M1: First Customer Vertical" `
+  --label "sprint:3"
+```
+
+Key rules:
+
+- **`--title`** matches the story heading: `US-NNN: Title`.
+- **`--body`** links back to the story file (the source of truth).
+- **`--milestone`** uses the milestone **title** (not number).
+- **`--label`** uses the `sprint:N` label for the current sprint.
+
+### Step 3: Add issues to the project board
+
+Issues are not automatically added to the project board. After
+creation, add them using the GraphQL API:
+
+```powershell
+$projectId = "PVT_kwHOAnH4YM4BTJvQ"
+$query = 'mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }'
+
+$issues = gh issue list --repo $repo --state open --json number,title,id | ConvertFrom-Json
+
+foreach ($issue in $issues) {
+    Write-Host "Adding #$($issue.number) ($($issue.title))..."
+    gh api graphql -f query="$query" -f projectId="$projectId" -f contentId="$($issue.id)"
+}
+```
+
+### Setting a sprint goal
+
+A sprint goal connects the sprint's work to a milestone objective.
+Format:
+
+> **Sprint N Goal:** *[Verb] [what] ([milestone reference]).*
+
+Examples:
+- *Ship the first customer vertical (M1) and document all three
+  contributor role workflows.*
+- *Complete dog management CRUD (M2).*
+
+The sprint goal goes in the sprint review document and optionally in
+the project board description.
+
+### Sprint capacity
+
+Consider:
+
+- Number of stories and total acceptance criteria count.
+- Technical infrastructure work (not captured in stories but needed
+  to deliver them — e.g., first-time database setup).
+- Stories that are documentation-only vs code — they can run in
+  parallel.
+- Historical velocity: Sprint 0 shipped 3 stories, Sprint 1 shipped
+  4, Sprint 2 shipped 11.
+
+## Board Management
+
+### Board structure
+
+The GitHub Projects board uses three columns:
+
+| Column | Meaning |
+|--------|---------|
+| **Todo** | Committed but not started |
+| **In Progress** | Actively being worked |
+| **Done** | Merged to main, AC verified |
+
+### Moving issues
+
+- Move to **In Progress** when a branch is created and work begins.
+- Move to **Done** only after the PR is merged and AC are verified.
+- Never move to Done based on PR creation alone.
+
+### Handling blocked issues
+
+When an issue is blocked:
+
+1. Add a comment to the issue explaining the blocker.
+2. If the blocker is another issue, link them with
+   `Blocked by #<number>`.
+3. Leave the issue in its current column — do not create a "Blocked"
+   column.
+4. Raise the blocker in standup or async check-in.
+
+### Tracking progress
+
+Sprint progress = issues in Done / total issues. Check the board
+view's built-in progress bar, or run:
+
+```powershell
+$repo = "frankjhughes/camp-fit-fur-dogs"
+$open = (gh issue list --repo $repo --label "sprint:3" --state open --json number | ConvertFrom-Json).Count
+$closed = (gh issue list --repo $repo --label "sprint:3" --state closed --json number | ConvertFrom-Json).Count
+$total = $open + $closed
+Write-Host "Sprint 3: $closed/$total done ($([math]::Round($closed/$total*100))%)"
+```
+
+## Sprint Review
+
+### Document format
+
+After each sprint, create a review document at
+`docs/sprint-reviews/sprint-N.md`:
+
+```markdown
+# Sprint N Review
+
+## Sprint Goal
+
+> [The sprint goal statement]
+
+## Shipped Stories
+
+| Issue | Story | Status |
+|-------|-------|--------|
+| #NN | US-NNN: Title | Done |
+
+## Key Decisions
+
+- [Decision made during the sprint and why]
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Stories committed | N |
+| Stories shipped | N |
+| Carry-over | N |
+| PRs merged | N |
+
+## Demo Notes
+
+[What was demonstrated and to whom]
+
+## Retrospective Items
+
+### What went well
+
+- [Item]
+
+### What could improve
+
+- [Item]
+
+### Action items
+
+- [ ] [Concrete action for next sprint]
+```
+
+### Compiling the review
+
+1. List all issues with the `sprint:N` label.
+2. For each, note whether it shipped (closed) or carried over (open).
+3. Summarize key decisions made during the sprint (ADRs, scope
+   changes, process changes).
+4. Record retro items while they're fresh.
+
+### Updating CHANGELOG.md
+
+After each merged PR, add an entry to CHANGELOG.md under the current
+sprint heading:
+
+```markdown
+## Sprint N
+
+### Added
+- US-NNN: Short description (#PR)
+
+### Changed
+- US-NNN: Short description (#PR)
+
+### Fixed
+- Description of fix (#PR)
+```
+
+### Updating README milestone progress
+
+After sprint review, update the milestone progress section in
+README.md to reflect current status:
+
+- Which milestones are complete, in progress, or not started.
+- How many stories remain in each active milestone.
+
+## Sprint Retrospective
+
+### Format
+
+Use a simple three-section retro:
+
+1. **What went well** — practices, tools, or decisions to keep.
+2. **What could improve** — friction, surprises, or mistakes.
+3. **Action items** — concrete, assignable changes for next sprint.
+
+### Rules
+
+- Action items must be specific ("Add a PR template") not vague
+  ("Improve code review").
+- Each action item gets assigned to a person.
+- Review previous retro action items at the start — were they done?
+- Retro items are recorded in the sprint review document.
+
+### Feeding retro into planning
+
+Action items from retro can become:
+
+- A new story (if the scope is large enough).
+- A task added to the next sprint's technical work.
+- A process change documented in governance.
+
+## Milestone Management
+
+### Milestones vs sprints
+
+These are independent concepts:
+
+| Concept | Question it answers | Lifecycle |
+|---------|-------------------|-----------|
+| **Milestone** | What capability goal are we building toward? | Spans multiple sprints |
+| **Sprint** | What will we finish in this timebox? | Fixed duration (1-2 weeks) |
+
+A sprint can contain stories from multiple milestones. A milestone
+can span multiple sprints.
+
+### Creating a GitHub Milestone
+
+```powershell
+gh api "repos/frankjhughes/camp-fit-fur-dogs/milestones" `
+  --method POST `
+  -f title="M4: Milestone Name" `
+  -f state=open `
+  -f description="One-sentence capability goal."
+```
+
+### Closing a milestone
+
+Close a milestone when all its stories have shipped:
+
+```powershell
+# Find the milestone number
+gh api "repos/frankjhughes/camp-fit-fur-dogs/milestones?state=open" | ConvertFrom-Json | Format-Table number, title
+
+# Close it
+gh api "repos/frankjhughes/camp-fit-fur-dogs/milestones/<number>" `
+  --method PATCH -f state=closed
+```
+
+When closing a milestone:
+
+1. Verify all assigned issues are closed.
+2. Record the completion in the sprint review document.
+3. Update README milestone progress.
+4. Consider a demo or case study for portfolio value.
+
+### Current milestones
+
+| Milestone | Goal |
+|-----------|------|
+| M1: First Customer Vertical | Account + dog registration + profile view |
+| M2: Complete Dog Management | Full CRUD + edge cases for dog records |
+| M3: Portfolio Showcase | Project documented, tooled, and presentable |
+
+## Merge Governance
+
+### Branch protection
+
+The `main` branch is protected:
+
+- Direct pushes are blocked — all changes go through PRs.
+- At least one CODEOWNERS approval is required.
+- All CI status checks must pass before merge.
+- Squash-merge is the default strategy.
+
+### CODEOWNERS
+
+The `CODEOWNERS` file defines who must review PRs based on file paths.
+When a PR touches files in a protected path, the corresponding owners
+are auto-assigned as reviewers.
+
+Review the current CODEOWNERS at
+[`CODEOWNERS`](../../CODEOWNERS).
+
+### PR checklist
+
+Before approving a PR:
+
+- [ ] Code compiles with zero warnings.
+- [ ] All tests pass.
+- [ ] New code has appropriate test coverage.
+- [ ] No unrelated changes bundled.
+- [ ] Commit messages follow the convention.
+- [ ] Story AC are addressed (check the linked issue).
+
+### Handling stale branches
+
+Branches that haven't been updated in 2+ weeks:
+
+1. Check if the associated issue is still in the sprint.
+2. If the work is abandoned, close the PR and move the issue back
+   to Todo (or remove from the sprint).
+3. Delete the stale branch.
+
+### Handling failed PRs
+
+When a PR can't be merged:
+
+1. If CI fails — fix the code and push.
+2. If review is rejected — address feedback and re-request review.
+3. If the approach is wrong — close the PR, discuss in the issue,
+   and open a new PR with a different approach.
+
+## Sprint Label Convention
+
+Each sprint gets a label: `sprint:N`.
+
+```powershell
+gh label create "sprint:4" --color "0E8A16" `
+  --description "Sprint 4 timebox" --force `
+  --repo frankjhughes/camp-fit-fur-dogs
+```
+
+Use consistent colors per sprint for visual distinction on the board.
+
+## Getting Help
+
+- Check the [Product Owner Guide](product-owner-guide.md) for story
+  and backlog questions.
+- Check the [Developer Guide](developer-guide.md) for code and PR
+  workflow.
+- Tag `@FrankJHughes` for process or governance questions.


### PR DESCRIPTION
Three role-based contributor guides and a restructured CONTRIBUTING.md hub.

## Deliverables

**Developer Guide** (US-009, closes #98)
- Prerequisites, Getting Started, project structure
- DDD architecture overview and key conventions
- Branch naming, commit messages, development loop
- dx.ps1 commands, testing strategy, PR process
- ADR format and when to write one

**Product Owner Workflow Guide** (US-045, closes #99)
- Story authoring format (customer vs docs/infra templates)
- File naming convention (ADR-0009)
- AC writing guidelines with good/bad examples
- Emotional Guarantees table (EG-01 through EG-07) and tagging workflow
- Definition of Ready (8 criteria with pass/fail examples)
- Backlog ops: add, retire, absorb, split, scope update rules
- Refinement triggers and milestone-driven prioritization

**Scrum Master Workflow Guide** (US-046, closes #100)
- 2-step workflow (stories = backlog, issues = sprint commitments)
- Sprint planning: story selection, issue creation, board addition
- Board management: columns, movement rules, blocked issues
- Sprint review template and CHANGELOG format
- Retrospective format with retro-to-planning feedback loop
- Milestone CRUD with CLI commands
- Merge governance: branch protection, CODEOWNERS, PR checklist

**CONTRIBUTING.md** — restructured as role-routing hub with emoji headers and quick links table.