### PR TITLE
backlog: add tech debt stories US-048, US-049, US-050 from US-027

### DIFF
--- a/product/stories/infra/US-048-compile-time-safe-command-dispatch.md
+++ b/product/stories/infra/US-048-compile-time-safe-command-dispatch.md
@@ -1,0 +1,21 @@
+# US-048 — Compile-Time-Safe Command Dispatch
+
+## Intent
+
+As a developer, I want the command dispatcher to use compile-time-safe resolution so that missing or misconfigured handlers are caught at build time, not at runtime.
+
+## Value
+
+The current `CommandDispatcher` uses reflection and `dynamic` to resolve handlers. This is invisible to the compiler — a missing handler registration silently compiles and explodes at runtime. Replacing it with a source-generated or explicit registration approach makes the system deterministic and refactor-safe.
+
+## Acceptance Criteria
+
+- [ ] `CommandDispatcher` no longer uses reflection or `dynamic` for handler resolution
+- [ ] A missing handler registration produces a compile-time error, not a runtime exception
+- [ ] All existing command/handler pairs continue to work with no behavior change
+- [ ] No new external dependencies required (source generators or manual registration are both acceptable)
+- [ ] Existing tests pass without modification
+
+## Emotional Guarantees
+
+- EG-01 No surprises

--- a/product/stories/infra/US-049-secure-password-hashing.md
+++ b/product/stories/infra/US-049-secure-password-hashing.md
@@ -1,0 +1,22 @@
+# US-049 — Secure Password Hashing
+
+## Intent
+
+As a security-conscious team, we want to replace the placeholder base64 password encoding with a production-grade hashing algorithm so that customer credentials are protected at rest.
+
+## Value
+
+The current `PasswordHash` value object uses `Convert.ToBase64String` — this is encoding, not hashing. Base64 is trivially reversible. Before any authentication story ships, this must be replaced with BCrypt, Argon2, or PBKDF2 to meet minimum security standards.
+
+## Acceptance Criteria
+
+- [ ] `PasswordHash.Create()` uses BCrypt, Argon2, or PBKDF2 (not base64)
+- [ ] Hashed values are not reversible to plaintext
+- [ ] `PasswordHash.Verify(plaintext, hash)` method is added for future login use
+- [ ] Existing `PasswordHash` unit tests are updated to validate the new behavior
+- [ ] No plaintext or base64-encoded passwords exist in the database after migration
+- [ ] The chosen algorithm and cost factor are documented in an ADR or inline comment
+
+## Emotional Guarantees
+
+- EG-03 Calm protection

--- a/product/stories/infra/US-050-unit-of-work-pattern.md
+++ b/product/stories/infra/US-050-unit-of-work-pattern.md
@@ -1,0 +1,22 @@
+# US-050 — Unit of Work Pattern
+
+## Intent
+
+As a developer, I want a Unit of Work abstraction so that cross-aggregate transactions are explicit, consistent, and testable.
+
+## Value
+
+Currently each repository calls `SaveChangesAsync` independently. This works for single-aggregate operations but breaks down when a use case spans multiple aggregates — partial commits become possible. A Unit of Work wraps the entire operation in a single transaction boundary.
+
+## Acceptance Criteria
+
+- [ ] `IUnitOfWork` interface is defined in the Application layer
+- [ ] `SaveChangesAsync` is removed from individual repository implementations
+- [ ] Command handlers call `IUnitOfWork.CommitAsync()` after all repository operations
+- [ ] Infrastructure implements `IUnitOfWork` backed by EF Core's `DbContext`
+- [ ] Existing `CreateCustomerHandler` is updated to use the new pattern
+- [ ] All existing tests pass without behavior change
+
+## Emotional Guarantees
+
+- EG-01 No surprises


### PR DESCRIPTION
## Summary

Adds three tech debt stories identified during US-027 (Create Customer Account) implementation. Each addresses a known shortcut that was acceptable for the first vertical slice but must be resolved before dependent stories ship.

| Story | Tech Debt | Risk If Deferred |
|-------|-----------|-----------------|
| US-048 | CommandDispatcher uses reflection + dynamic | Runtime failures from missing handlers |
| US-049 | PasswordHash uses base64 encoding | Customer credentials stored reversibly |
| US-050 | No Unit of Work pattern | Partial commits in multi-aggregate use cases |

Closes # N/A — backlog story additions; no issues created until pulled into a sprint.

## Changes

- Added `product/stories/infra/US-048-compile-time-safe-command-dispatch.md`
- Added `product/stories/infra/US-049-secure-password-hashing.md`
- Added `product/stories/infra/US-050-unit-of-work-pattern.md`

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [ ] Docs updated (if applicable) — N/A, backlog files only
- [ ] Changelog updated under Unreleased (if user-facing) — N/A, no user-facing change
- [x] No secrets or credentials committed