### PR TITLE
docs: fix dx.ps1 references and add TDD section to developer guide

### DIFF
--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -1,8 +1,6 @@
 # Developer Contributor Guide
 
-Welcome to Camp Fit Fur Dogs. This guide covers everything you need to
-clone the repo, run the app locally, and ship code through our pull
-request workflow.
+Welcome to Camp Fit Fur Dogs. This guide covers everything you need to clone the repo, run the app locally, and ship code through our pull request workflow.
 
 ## Prerequisites
 
@@ -41,55 +39,47 @@ dotnet run --project src/CampFitFurDogs.Api
 ```
 camp-fit-fur-dogs/
 ├── src/
-│   ├── CampFitFurDogs.Api/           # ASP.NET Core host, controllers, middleware
-│   ├── CampFitFurDogs.Application/   # Use cases, command/query handlers
-│   ├── CampFitFurDogs.Domain/        # Aggregates, entities, value objects, domain events
-│   └── CampFitFurDogs.Infrastructure/# EF Core, repos, external service adapters
+│   ├── CampFitFurDogs.Api/             # ASP.NET Core host, controllers, middleware
+│   ├── CampFitFurDogs.Application/     # Use cases, command/query handlers
+│   ├── CampFitFurDogs.Domain/          # Aggregates, entities, value objects, domain events
+│   └── CampFitFurDogs.Infrastructure/  # EF Core, repos, external service adapters
 ├── tests/
 │   ├── CampFitFurDogs.Domain.Tests/
 │   └── CampFitFurDogs.Api.Tests/
 ├── product/
-│   ├── stories/                      # Backlog (the source of truth)
+│   ├── stories/                        # Backlog (the source of truth)
 │   ├── definition-of-ready/
 │   └── emotional-guarantees/
 ├── docs/
-│   ├── adr/                          # Architecture Decision Records
-│   ├── sprint-reviews/               # Sprint review documents
-│   ├── governance/                   # Process governance
-│   └── guides/                       # ← You are here
-├── CONTRIBUTING.md                   # Role-routing hub
-├── CODEOWNERS                        # PR review assignments
-├── CHANGELOG.md                      # Release history
-└── dx.ps1                            # Developer experience script
+│   ├── adr/                            # Architecture Decision Records
+│   ├── sprint-reviews/                 # Sprint review documents
+│   ├── governance/                     # Process governance
+│   └── guides/                         # ← You are here
+├── CONTRIBUTING.md                     # Role-routing hub
+├── CODEOWNERS                          # PR review assignments
+└── CHANGELOG.md                        # Release history
 ```
 
 ## Architecture
 
-The codebase follows Domain-Driven Design with four layers. Dependencies
-point inward — Domain has zero external references.
+The codebase follows Domain-Driven Design with four layers. Dependencies point inward — Domain has zero external references.
 
 ```
 Api → Application → Domain
  └→ Infrastructure → Domain
 ```
 
-- **Domain** — aggregates, value objects, domain events, repository
-  interfaces. No framework dependencies.
-- **Application** — command and query handlers that orchestrate domain
-  logic. References Domain only.
-- **Infrastructure** — EF Core DbContext, repository implementations,
-  external adapters. References Domain for interface contracts.
-- **Api** — ASP.NET Core host, controllers, middleware, DI composition
-  root. References all layers.
+- **Domain** — aggregates, value objects, domain events, repository interfaces. No framework dependencies.
+- **Application** — command and query handlers that orchestrate domain logic. References Domain only.
+- **Infrastructure** — EF Core DbContext, repository implementations, external adapters. References Domain for interface contracts.
+- **Api** — ASP.NET Core host, controllers, middleware, DI composition root. References all layers.
 
 ### Key conventions
 
 - One aggregate per file, named after the aggregate root.
 - Value objects are `record` types in the aggregate's namespace.
-- Repository interfaces live in Domain; implementations in
-  Infrastructure.
-- No reflection, no magic strings — explicit, compile-time-safe
-  bindings.
+- Repository interfaces live in Domain; implementations in Infrastructure.
+- No reflection, no magic strings — explicit, compile-time-safe bindings.
 
 ## Development Workflow
 
@@ -107,8 +97,7 @@ Api → Application → Domain
 | `infra/` | CI/CD, tooling, config |
 | `refactor/` | Internal restructuring |
 
-Examples: `feature/us-027-create-customer-account`,
-`docs/sprint-3-stories`, `infra/ci-pipeline`.
+Examples: `feature/us-027-create-customer-account`, `docs/sprint-3-stories`, `infra/ci-pipeline`.
 
 ### Commit messages
 
@@ -120,8 +109,7 @@ Use conventional-style commits:
 <optional body explaining why, not what>
 ```
 
-Types match branch types: `feature`, `fix`, `docs`, `infra`,
-`refactor`.
+Types match branch types: `feature`, `fix`, `docs`, `infra`, `refactor`.
 
 ### Development loop
 
@@ -136,30 +124,63 @@ Types match branch types: `feature`, `fix`, `docs`, `infra`,
 
 ```powershell
 # Full build
-./dx.ps1 build
+dotnet build
 
 # Run the API (with hot reload)
-./dx.ps1 up
+dotnet watch --project src/CampFitFurDogs.Api
 
 # Run all tests
-./dx.ps1 test
+dotnet test
+
+# Start local infrastructure
+docker compose up -d
 
 # Tear down local containers
-./dx.ps1 down
+docker compose down
 
-# Reset local database
-./dx.ps1 db-reset
+# Reset local database (destroy volume and recreate)
+docker compose down -v && docker compose up -d
 ```
+
+## Test-Driven Development (TDD)
+
+All feature work follows Red-Green-Refactor. Every vertical slice begins with a failing test.
+
+### The cycle
+
+1. **Red** — Write a test that describes the behavior you want. Run it. Watch it fail. The failure message confirms you are testing the right thing.
+2. **Green** — Write the minimum production code to make the test pass. No more.
+3. **Refactor** — Clean up duplication, naming, and structure while all tests stay green.
+
+### Slice order
+
+Build each feature from the inside out, one layer at a time:
+
+| Order | Layer | What to test | Example |
+|-------|-------|--------------|---------|
+| 1 | Domain | Value object invariants, aggregate factory rules | `DogName rejects empty string` |
+| 2 | Domain | Aggregate behavior and state transitions | `Dog.Create sets all properties` |
+| 3 | Application | Command handler orchestration (mock the repo) | `RegisterDogHandler persists dog` |
+| 4 | Infrastructure | Repository round-trip against a real test DB | `DogRepository can save and retrieve` |
+| 5 | API | Full HTTP request/response via WebApplicationFactory | `POST /customers/{id}/dogs returns 201` |
+
+### Conventions
+
+- Name tests to describe the scenario: `RegisterDog_WithMissingName_ReturnsBadRequest`.
+- Domain tests are pure — no mocks, no infrastructure, no DI container.
+- API tests use `WebApplicationFactory` with a real PostgreSQL test container.
+- One test class per aggregate or endpoint. Group related scenarios with nested classes.
+
+### When to skip TDD
+
+TDD is required for all domain logic, command handlers, and API endpoints. Configuration-only changes (DI registration, EF mappings, middleware wiring) do not need dedicated tests but must be exercised by the integration tests above.
 
 ## Testing
 
-- **Domain tests** — pure unit tests, no mocks, no infrastructure.
-  Test aggregate behavior and value object invariants.
-- **API tests** — integration tests using `WebApplicationFactory`.
-  Test HTTP endpoints against a real test database.
+- **Domain tests** — pure unit tests, no mocks, no infrastructure. Test aggregate behavior and value object invariants.
+- **API tests** — integration tests using `WebApplicationFactory`. Test HTTP endpoints against a real test database.
 
-Name test methods to describe the scenario:
-`CreateAccount_WithDuplicateEmail_ReturnsConflict`.
+Name test methods to describe the scenario: `CreateAccount_WithDuplicateEmail_ReturnsConflict`.
 
 Run tests before pushing:
 
@@ -182,7 +203,7 @@ dotnet test --verbosity normal
 Before requesting review, confirm:
 
 - [ ] Code compiles with zero warnings.
-- [ ] All tests pass locally (`./dx.ps1 test`).
+- [ ] All tests pass locally (`dotnet test`).
 - [ ] New code has tests covering the happy path and key edge cases.
 - [ ] No unrelated changes bundled into the PR.
 - [ ] Commit history is clean (squash fixups before review).
@@ -228,14 +249,11 @@ Browse the full list at [`docs/adr/`](../../docs/adr/).
 
 ## Code of Conduct
 
-Be kind. Be constructive. Assume good intent. Every contributor —
-regardless of experience level — deserves respect and clear feedback.
+Be kind. Be constructive. Assume good intent. Every contributor — regardless of experience level — deserves respect and clear feedback.
 
 ## Getting Help
 
 - Open a GitHub Discussion for questions.
 - Tag `@FrankJHughes` for architecture or process questions.
-- Check the [Product Owner Guide](product-owner-guide.md) for story
-  and backlog questions.
-- Check the [Scrum Master Guide](scrum-master-guide.md) for sprint
-  and board questions.
+- Check the [Product Owner Guide](product-owner-guide.md) for story and backlog questions.
+- Check the [Scrum Master Guide](scrum-master-guide.md) for sprint and board questions.


### PR DESCRIPTION
## Summary

The developer guide still references `dx.ps1` in three locations despite an earlier fix attempt — the Building and Running code block, the Project Structure tree, and the PR checklist. This PR replaces all remaining references with standard `dotnet` and `docker compose` commands that work today.

Additionally, adds a new **Test-Driven Development (TDD)** section documenting the Red-Green-Refactor cycle, layer-by-layer slice order, naming conventions, and when TDD is required vs. optional. This codifies the workflow established during US-027.

Closes # N/A — doc hygiene and process documentation.

## Changes

All in `docs/guides/developer-guide.md`:

| Section | Change |
|---------|--------|
| Project Structure tree | Removed `dx.ps1` line |
| Building and Running | Replaced 5 `./dx.ps1` commands with `dotnet` / `docker compose` equivalents |
| PR checklist | Changed `./dx.ps1 test` to `dotnet test` |
| TDD (new section) | Added Red-Green-Refactor cycle, slice order table, conventions, skip guidance |

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [ ] Changelog updated under Unreleased (if user-facing) — N/A, internal docs only
- [x] No secrets or credentials committed