### PR TITLE
fix: remove invalid git update-index from hook install docs

### DIFF
--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -135,7 +135,6 @@ The repo ships a ready-made hook in `hooks/`. Install it once after cloning:
 
 ```powershell
 Copy-Item hooks/pre-push .git/hooks/pre-push
-git update-index --chmod=+x .git/hooks/pre-push
 ```
 
 After this, `git push origin main` will be rejected locally with a clear message before the push ever hits the network.


### PR DESCRIPTION
## Summary

Remove `git update-index --chmod=+x` from the pre-push hook install instructions. That command only works on tracked files — `.git/hooks/` is untracked, so it fails with a fatal error. The copy alone is sufficient; Git on Windows executes hooks via the shebang regardless of the executable bit.

## Changes

- **`docs/guides/developer-guide.md`** — removed broken `git update-index` line from hook install steps

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [x] Docs updated (if applicable)
- [ ] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed