### PR TITLE
docs: ADR-0012 — Frontend Technology (React/Next.js)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `.github/copilot-instructions.md` — living conventions document (standing rules, PR conventions, architecture patterns, tooling, lessons learned)
 - Sprint review closing checklist in `docs/sprint-reviews/_template.md`
 - Conventions maintenance sections in all three contributor guides
+- ADR-0012: Frontend Technology — React with Next.js (US-055)
 ## [Sprint 3] — 2026-04-11
 
 ### Completed Stories

--- a/docs/adr/0012-frontend-technology-react-nextjs.md
+++ b/docs/adr/0012-frontend-technology-react-nextjs.md
@@ -1,0 +1,90 @@
+# ADR-0012: Frontend Technology — React with Next.js
+
+| Field     | Value                              |
+|-----------|------------------------------------|
+| Status    | Accepted                           |
+| Date      | 2026-04-11                         |
+| Deciders  | Frank Hughes                       |
+
+## Context
+
+Camp Fit Fur Dogs has a .NET backend using DDD layered architecture
+(ADR-0002) with CQRS command/query pipelines. Sprint 4 introduces the
+first frontend vertical slice — the Register Dog Page (US-084). Before
+building UI, the team needs to commit to a frontend framework so that
+all subsequent stories share a common technology, folder structure, and
+testing approach.
+
+The chosen framework must:
+
+- Support TypeScript for compile-time safety across the stack.
+- Integrate cleanly with the .NET API via dev-server proxying.
+- Provide a mature testing story compatible with TDD (red-green-refactor).
+- Have a large ecosystem for component libraries, tooling, and hiring.
+- Support server-side rendering and static generation for future needs.
+
+## Decision
+
+We will use **React** with **Next.js** and **TypeScript** as the
+frontend technology stack.
+
+### Alternatives Considered
+
+| Alternative         | Strengths                                        | Why Not                                                       |
+|---------------------|--------------------------------------------------|---------------------------------------------------------------|
+| **Blazor (WASM)**   | Single language (.NET/C#); shared domain models  | Smaller ecosystem; less mature component testing; larger WASM payload; limited community resources for rapid problem-solving |
+| **Blazor (Server)** | Single language; no WASM payload                 | Requires persistent SignalR connection; latency on every interaction; poor offline story |
+| **Angular**         | Full framework; strong TypeScript integration    | Heavier; steeper learning curve; more opinionated than needed for this project's scope |
+| **Vue + Nuxt**      | Lighter than Angular; good DX                    | Smaller ecosystem than React; fewer testing patterns documented; less hiring reach |
+
+### Why React + Next.js
+
+- **Ecosystem size** — React has the largest component library and
+  tooling ecosystem. Problems encountered during development are likely
+  already solved and documented.
+- **Testing maturity** — Vitest + React Testing Library provide fast,
+  reliable component testing that supports TDD at the UI layer. This is
+  critical for the project's strict red-green-refactor discipline.
+- **Next.js conventions** — File-based routing, API route proxying, and
+  built-in dev server simplify the integration with the .NET backend.
+  The dev server proxy eliminates CORS configuration during development.
+- **TypeScript first-class** — Next.js scaffolds with TypeScript by
+  default. The typed API client layer (US-102) benefits from end-to-end
+  type safety.
+- **Future flexibility** — Server-side rendering (SSR) and static site
+  generation (SSG) are available if the product evolves toward public
+  pages, SEO, or performance-sensitive views.
+
+## Consequences
+
+### Positive
+
+- Large talent pool and community support for onboarding contributors.
+- Vitest + React Testing Library enable TDD at the component layer from
+  day one (US-103).
+- Next.js dev server proxy provides seamless local development against
+  the .NET API without CORS configuration.
+- File-based routing reduces boilerplate and enforces naming conventions.
+- TypeScript catches integration errors at compile time, especially in
+  the typed API client (US-102).
+
+### Negative
+
+- Two language ecosystems (.NET + Node.js) increase build complexity.
+  CI must build, test, and lint both stacks.
+- Contributors need proficiency in both C# and TypeScript. The skill
+  overlap is common but not universal.
+- Node.js tooling (npm, Vitest, ESLint) adds a second dependency tree
+  to manage and keep secure.
+
+### Neutral
+
+- Frontend folder conventions, API client patterns, and testing
+  patterns must be established as part of the scaffold (US-056) and
+  testing setup (US-103). These are Sprint 4 deliverables and become
+  the reference for all future UI work.
+- The decision does not constrain the backend in any way. The .NET API
+  remains framework-agnostic — any frontend could consume it.
+- Deployment model (static export vs. Node.js server vs. containerized)
+  is a separate decision deferred until the product approaches
+  production readiness.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,5 @@ New ADRs should follow [TEMPLATE.md](TEMPLATE.md).
 | [0008](0008-consistent-editor-experience.md) | Consistent Editor Experience | Accepted |
 | [0009](0009-story-naming-convention.md) | Story Naming Convention | Accepted |
 | [0010](0010-retire-planning-yaml-infrastructure.md) | Retire Planning YAML Infrastructure | Accepted |
+
+| [0012](0012-frontend-technology-react-nextjs.md) | Frontend Technology — React with Next.js | Accepted |


### PR DESCRIPTION
## Summary

Adds ADR-0012 documenting the decision to use React with Next.js and TypeScript as the frontend technology for Camp Fit Fur Dogs.

Closes #114

## What Changed

- **New file:** `docs/adr/0012-frontend-technology-react-nextjs.md`
- **Updated:** `docs/adr/README.md` — added ADR-0012 to the index

## Decision

**React + Next.js + TypeScript** — chosen for ecosystem size, testing maturity (Vitest + React Testing Library), TypeScript-first support, and Next.js dev server proxying to the .NET API.

### Alternatives Considered

| Alternative | Why Not |
|-------------|---------|
| Blazor (WASM) | Smaller ecosystem; less mature component testing; larger payload |
| Blazor (Server) | Persistent SignalR connection; latency; poor offline story |
| Angular | Heavier; steeper learning curve; more opinionated than needed |
| Vue + Nuxt | Smaller ecosystem; fewer documented testing patterns |

## Sprint 4 Impact

This ADR unblocks:
- **US-056** (#122) — Next.js Project Scaffold
- **US-102** (#123) — API Client Layer
- **US-103** (#124) — Frontend Testing Setup
- **US-084** (#118) — Register Dog Page (proving slice)

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (Build & Test) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed