### PR TITLE
feat(frontend): API client with typed error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - ADR-0012: Frontend Technology — React with Next.js (US-055)
 - `.gitattributes` — enforces LF line endings repo-wide; eliminates CRLF phantom diffs in Dev Container
 - First-Time Setup section in `docs/guides/developer-guide.md` (Docker Desktop auto-start, Git identity, hooks)
+- Frontend API client with typed error handling and unit test suite (see `frontend/CHANGELOG.md`)
 
 ### Changed
 

--- a/docs/guides/frontend-testing.md
+++ b/docs/guides/frontend-testing.md
@@ -1,0 +1,104 @@
+# Frontend Testing Guide
+
+## Quick Start
+
+```powershell
+cd frontend
+npm test              # watch mode
+npm test -- --run     # single run (CI)
+npx vitest --run      # skip npm overhead
+```
+
+## Test Projects
+
+The Vitest config defines two projects with different environments:
+
+| Project | Environment | Glob | Use for |
+|---|---|---|---|
+| `unit` | `node` | `test/lib/**/*.test.ts` | API client, utilities, pure logic |
+| `components` | `jsdom` | `test/app/**`, `test/components/**` | React components, pages, hooks with DOM |
+
+**Why?** jsdom initialization is expensive in Docker. Scoping it to component tests only keeps unit tests fast (~50ms vs ~300s).
+
+## Writing a Unit Test (node environment)
+
+```typescript
+// test/lib/api/client.test.ts
+import { createApiClient } from '@/lib/api/client';
+
+describe('ApiClient', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns ok with data on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 1 }),
+    }));
+
+    const client = createApiClient('http://localhost');
+    const result = await client.get('/dogs');
+
+    expect(result).toEqual({ ok: true, data: { id: 1 } });
+  });
+});
+```
+
+**Key points:**
+- Use `vi.stubGlobal('fetch', ...)` to mock fetch — no jsdom needed
+- `afterEach(() => vi.restoreAllMocks())` cleans up between tests
+- Import from `@/lib/...` — the path alias resolves to `src/lib/...`
+
+## Writing a Component Test (jsdom environment)
+
+```typescript
+// test/app/page.test.tsx
+import { render, screen } from '@testing-library/react';
+import Home from '@/app/page';
+
+describe('Home page', () => {
+  it('renders the heading', () => {
+    render(<Home />);
+    expect(
+      screen.getByRole('heading', { name: /camp fit fur dogs/i }),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+**Key points:**
+- `render()` and `screen` come from `@testing-library/react`
+- `toBeInTheDocument()` comes from `jest-dom` matchers (loaded via `test/setup.ts`)
+- Component tests are slower due to jsdom — keep assertions focused
+
+## Where to Put Tests
+
+```
+test/
+├── setup.ts                    # jest-dom matchers (jsdom project only)
+├── app/
+│   └── page.test.tsx           # page component tests
+├── components/
+│   └── *.test.tsx              # shared component tests
+└── lib/
+    └── api/
+        └── client.test.ts      # API client unit tests
+```
+
+Mirror the `src/` structure under `test/`. The glob patterns in `vitest.config.mts` determine which project (and environment) picks up each file.
+
+## TDD Workflow
+
+1. **Red** — Write the failing test first
+2. **Green** — Write the minimum code to pass
+3. **Refactor** — Clean up duplication, extract helpers
+4. Run `npx vitest --run` after each step to confirm state
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tests take 300+ seconds | All tests running in jsdom | Ensure unit tests match the `unit` project glob |
+| `Cannot find module '@/lib/...'` | test/tsconfig.json path alias | Verify `paths: { "@/*": ["../src/*"] }` in `test/tsconfig.json` |
+| VS Code red squiggles but tests pass | Stale TS server | `Ctrl+Shift+P` → TypeScript: Restart TS Server |
+| Plugin type errors in vitest.config.mts | Vite version mismatch (Next.js vs Vitest) | Keep the `as any` cast on the plugins array |

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -13,6 +13,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `npm test` runs all frontend tests
 - Testing guide (`docs/testing-guide.md`) — how to write and run component tests
 - `vite-tsconfig-paths` plugin for `@/*` path alias resolution in tests
+- API client (`src/lib/api/client.ts`) — `createApiClient(baseUrl)` factory with `get`, `post`, `put`, `delete` and discriminated-union `ApiResult<T>` return type
+- Three typed error channels: `network`, `http`, `validation` (422 with per-field errors)
+- 7 unit tests for API client covering all verbs and error paths
 
 ### Changed
 - Restructured project layout — moved `package.json` and configs from `frontend/src/` up to `frontend/` (project root). `src/` now contains only application source code.
+- Vitest config migrated from global `environment: 'jsdom'` to `test.projects` — unit tests run in `node` (~50ms), component tests in `jsdom`
+- `test/tsconfig.json` — fixed `@/*` path alias and source file inclusion for VS Code IntelliSense

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,67 @@
+export interface ApiError {
+  type: 'network' | 'http' | 'validation';
+  message: string;
+  status?: number;
+  errors?: Record<string, string[]>;
+}
+
+export type ApiResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: ApiError };
+
+export function createApiClient(baseUrl: string = '/api') {
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<ApiResult<T>> {
+    try {
+      const options: RequestInit = {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+      };
+      if (body !== undefined) {
+        options.body = JSON.stringify(body);
+      }
+      const response = await fetch(`${baseUrl}${path}`, options);
+      const data = await response.json();
+      if (!response.ok) {
+        if (response.status === 422) {
+          return {
+            ok: false,
+            error: {
+              type: 'validation',
+              status: 422,
+              message: data.message ?? 'Validation failed',
+              errors: data.errors,
+            },
+          };
+        }
+        return {
+          ok: false,
+          error: {
+            type: 'http',
+            status: response.status,
+            message: data.message ?? 'Request failed',
+          },
+        };
+      }
+      return { ok: true, data };
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          type: 'network',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      };
+    }
+  }
+
+  return {
+    get: <T>(path: string) => request<T>('GET', path),
+    post: <T>(path: string, body: unknown) => request<T>('POST', path, body),
+    put: <T>(path: string, body: unknown) => request<T>('PUT', path, body),
+    delete: <T>(path: string) => request<T>('DELETE', path),
+  };
+}

--- a/frontend/test/lib/api/client.test.ts
+++ b/frontend/test/lib/api/client.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createApiClient } from '@/lib/api/client';
+
+describe('ApiClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET', () => {
+    it('returns ok with data on successful response', async () => {
+      const mockData = { id: 1, name: 'Buddy' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockData),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.get('/dogs');
+
+      expect(fetch).toHaveBeenCalledWith('http://localhost/dogs', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(result).toEqual({ ok: true, data: mockData });
+    });
+
+    it('returns network error when fetch throws', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.get('/dogs');
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          type: 'network',
+          message: 'Failed to fetch',
+        },
+      });
+    });
+
+    it('returns http error on non-ok response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ message: 'Internal Server Error' }),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.get('/dogs');
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          type: 'http',
+          status: 500,
+          message: 'Internal Server Error',
+        },
+      });
+    });
+
+    it('returns validation error with field errors on 422', async () => {
+      const body = {
+        message: 'Validation failed',
+        errors: { name: ['Name is required'], age: ['Must be positive'] },
+      };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 422,
+          json: () => Promise.resolve(body),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.get('/dogs');
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          type: 'validation',
+          status: 422,
+          message: 'Validation failed',
+          errors: { name: ['Name is required'], age: ['Must be positive'] },
+        },
+      });
+    });
+
+    // next test for GET would go here
+
+  });
+
+  describe('POST', () => {
+    it('sends body and returns ok with data on success', async () => {
+      const requestBody = { name: 'Buddy', breed: 'Labrador' };
+      const responseData = { id: 1, name: 'Buddy', breed: 'Labrador' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve(responseData),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.post('/dogs', requestBody);
+
+      expect(fetch).toHaveBeenCalledWith('http://localhost/dogs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+      expect(result).toEqual({ ok: true, data: responseData });
+    });
+
+    // next test for POST would go here
+  });
+
+  describe('PUT', () => {
+    it('sends body and returns ok with data on success', async () => {
+      const requestBody = { name: 'Buddy Jr' };
+      const responseData = { id: 1, name: 'Buddy Jr', breed: 'Labrador' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(responseData),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.put('/dogs/1', requestBody);
+
+      expect(fetch).toHaveBeenCalledWith('http://localhost/dogs/1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+      expect(result).toEqual({ ok: true, data: responseData });
+    });
+  });
+
+  describe('DELETE', () => {
+    it('returns ok with data on success', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ deleted: true }),
+        }),
+      );
+
+      const client = createApiClient('http://localhost');
+      const result = await client.delete('/dogs/1');
+
+      expect(fetch).toHaveBeenCalledWith('http://localhost/dogs/1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(result).toEqual({ ok: true, data: { deleted: true } });
+    });
+  });
+
+});

--- a/frontend/test/tsconfig.json
+++ b/frontend/test/tsconfig.json
@@ -1,4 +1,16 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts", "**/*.tsx"]
+  "compilerOptions": {
+    "paths": {
+      "@/*": [
+        "../src/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "../src/**/*.ts",
+    "../src/**/*.tsx"
+  ]
 }

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -3,11 +3,29 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [tsconfigPaths(), react()],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugins: [tsconfigPaths(), react()] as any,
   test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./test/setup.ts'],
-    include: ['./test/**/*.test.{ts,tsx}'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          environment: 'node',
+          globals: true,
+          include: ['./test/lib/**/*.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'components',
+          environment: 'jsdom',
+          globals: true,
+          setupFiles: ['./test/setup.ts'],
+          include: ['./test/app/**/*.test.{ts,tsx}', './test/components/**/*.test.{ts,tsx}'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Adds a typed API client factory (`createApiClient`) with `get`, `post`, `put`, `delete` methods and discriminated-union result type (`ApiResult<T>`). Three error channels: `network`, `http`, `validation` (422 with per-field errors).

Migrates Vitest config to `test.projects` — unit tests run in `node` (~50ms), component tests in `jsdom`.

Closes #123

## Changes

- `frontend/src/lib/api/client.ts` — API client factory
- `frontend/test/lib/api/client.test.ts` — 7 unit tests (all verbs + error paths)
- `frontend/vitest.config.mts` — test.projects split (node + jsdom)
- `frontend/test/tsconfig.json` — path alias + source inclusion fix
- `docs/guides/frontend-testing.md` — testing guide
- `frontend/CHANGELOG.md` + root `CHANGELOG.md` updated

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (Build & Test) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed