### PR TITLE
chore: add GitHub CLI to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,8 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"
-    }
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "containerEnv": {
     "TESTCONTAINERS_RYUK_DISABLED": "true",


### PR DESCRIPTION
## Summary

Adds the GitHub CLI (`gh`) to the dev container so issue and PR management can be done without leaving the terminal.

## Changes

- `.devcontainer/devcontainer.json` — added `ghcr.io/devcontainers/features/github-cli:1` to features

## Notes

- VS Code automatically forwards host `gh` credentials into the container — no PAT or manual login needed.
- Requires a container rebuild after merge.

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (Build & Test) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [ ] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed
