### PR TITLE
chore: fix overlapping editorconfig globs, add frontend section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,9 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{cs,csproj,sln}]
-indent_size = 4
-
 # C# files
 [*.cs]
+indent_size = 4
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 csharp_new_line_before_open_brace = all
@@ -42,6 +40,10 @@ indent_size = 2
 # Markdown — trailing whitespace can be intentional (line breaks)
 [*.md]
 trim_trailing_whitespace = false
+
+# TypeScript / JavaScript / CSS (Next.js frontend)
+[*.{ts,tsx,js,jsx,css,scss}]
+indent_size = 2
 
 # Makefiles — must use tabs
 [Makefile]


### PR DESCRIPTION
## Summary

Cleans up `.editorconfig` overlapping globs and adds an explicit
frontend section for contributor clarity.

## Changes

- **`.editorconfig`** — removed `[*.{cs,csproj,sln}]` glob (its
  `indent_size = 4` was silently overridden back to 2 by the later
  `[*.{sln,slnx,csproj,props,targets}]` glob); merged `indent_size = 4`
  into the existing `[*.cs]` section where it belongs; added explicit
  `[*.{ts,tsx,js,jsx,css,scss}]` section documenting frontend indent
  convention for new contributors

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [ ] CI (Build & Test) is passing
- [x] Self-review completed
- [x] Docs updated (N/A — config only)
- [x] Changelog updated under Unreleased (N/A — not user-facing)
- [x] No secrets or credentials committed
