### PR TITLE
feat: resolve OwnerId from ICurrentUserService (US-084)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,6 +132,15 @@ Writes and reads are separated at the application layer:
 
 Consolidated into `Endpoints.cs` using the `MapGroup` pattern.
 
+### Identity Resolution
+
+Endpoints never accept user identity (e.g., `OwnerId`) from the request body. Identity is resolved server-side via `ICurrentUserService`.
+
+- **Abstraction:** `ICurrentUserService` lives in the Application layer (`Application/Abstractions/`).
+- **Production:** `DummyCurrentUserService` (Infrastructure) returns a hardcoded placeholder. Replace with a real implementation when authentication lands — the replacement will need `Scoped` lifetime (reads from `HttpContext`).
+- **Tests:** `TestCurrentUserService` (Api.Tests) exposes a settable `CurrentUserId`. The test factory overrides the DI registration so tests control which user the endpoint sees.
+- **Pattern:** Endpoint binds a DTO (e.g., `RegisterDogRequest`), injects `ICurrentUserService`, and constructs the command by combining both.
+
 ---
 
 ## Frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -15,10 +15,15 @@ All notable changes to this project will be documented in this file.
 - `.gitattributes` — enforces LF line endings repo-wide; eliminates CRLF phantom diffs in Dev Container
 - First-Time Setup section in `docs/guides/developer-guide.md` (Docker Desktop auto-start, Git identity, hooks)
 - Frontend API client with typed error handling and unit test suite (see `frontend/CHANGELOG.md`)
+- `ICurrentUserService` abstraction for server-side identity resolution (#118)
+- `RegisterDogRequest` API DTO — request body no longer includes `OwnerId` (#118)
+- `DummyCurrentUserService` pre-auth placeholder in Infrastructure (#118)
+- `ApiTestHelpers` shared test utilities for owner/dog creation (#118)
 
 ### Changed
 
 - Frontend relocated from `src/frontend/` to `frontend/src/` for role-based monorepo layout
+- `POST /api/dogs` endpoint resolves owner identity from `ICurrentUserService` instead of request body (#118)
 
 - `.devcontainer/devcontainer.json` — adds `TESTCONTAINERS_RYUK_DISABLED` and `TESTCONTAINERS_HOST_OVERRIDE` for docker-outside-of-docker Testcontainers compatibility
 - Root `.gitignore` — moves `node_modules/` and `.next/` to `frontend/src/.gitignore`; adds scratch file exclusions

--- a/frontend/src/api/registerDog.ts
+++ b/frontend/src/api/registerDog.ts
@@ -1,0 +1,29 @@
+import type { RegisterDogFormData } from '@/components/RegisterDogForm';
+
+export interface RegisterDogResult {
+  success: boolean;
+  errors?: Record<string, string>;
+}
+
+export async function registerDog(data: RegisterDogFormData): Promise<RegisterDogResult> {
+  try {
+    const response = await fetch('/api/dogs/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      try {
+        const body = await response.json();
+        return { success: false, errors: body.errors };
+      } catch {
+        return { success: false, errors: { form: 'An unexpected error occurred. Please try again.' } };
+      }
+    }
+
+    return response.json();
+  } catch {
+    return { success: false, errors: { form: 'A network error occurred. Please try again.' } };
+  }
+}

--- a/frontend/src/app/dogs/register/page.tsx
+++ b/frontend/src/app/dogs/register/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RegisterDogForm, type RegisterDogFormData } from '@/components/RegisterDogForm';
+import { registerDog } from '@/api/registerDog';
+
+export default function RegisterDogPage() {
+  const router = useRouter();
+  const [errors, setErrors] = useState<Record<string, string> | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (data: RegisterDogFormData) => {
+    setIsSubmitting(true);
+    setErrors(undefined);
+
+    const result = await registerDog(data);
+
+    if (result.success) {
+      router.push('/dogs/register/success');
+    } else {
+      setErrors(result.errors);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <RegisterDogForm
+      onSubmit={handleSubmit}
+      errors={errors}
+      isSubmitting={isSubmitting}
+    />
+  );
+}

--- a/frontend/src/app/dogs/register/success/page.tsx
+++ b/frontend/src/app/dogs/register/success/page.tsx
@@ -1,0 +1,8 @@
+export default function SuccessPage() {
+  return (
+    <div>
+      <h1>Registration Successful</h1>
+      <p>Your dog has been registered.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/RegisterDogForm.tsx
+++ b/frontend/src/components/RegisterDogForm.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface RegisterDogFormData {
+  name: string;
+  breed: string;
+  dateOfBirth: string;
+  sex: string;
+}
+
+interface RegisterDogFormProps {
+  onSubmit: (data: RegisterDogFormData) => void;
+  errors?: Record<string, string>;
+  isSubmitting?: boolean;
+}
+
+export function RegisterDogForm({ onSubmit, errors, isSubmitting }: RegisterDogFormProps) {
+  const [name, setName] = useState('');
+  const [breed, setBreed] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState('');
+  const [sex, setSex] = useState('');
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+
+  const displayErrors = { ...validationErrors, ...errors };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const newErrors: Record<string, string> = {};
+    if (!name.trim()) newErrors.name = 'Name is required';
+    if (!breed.trim()) newErrors.breed = 'Breed is required';
+    if (!dateOfBirth.trim()) newErrors.dateOfBirth = 'Date of birth is required';
+    if (!sex) newErrors.sex = 'Sex is required';
+
+    if (Object.keys(newErrors).length > 0) {
+      setValidationErrors(newErrors);
+      return;
+    }
+
+    setValidationErrors({});
+    onSubmit({ name, breed, dateOfBirth, sex });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h1>Register Dog</h1>
+
+      {displayErrors.form && <p>{displayErrors.form}</p>}
+
+      <label>
+        Name
+        <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
+      </label>
+      {displayErrors.name && <p>{displayErrors.name}</p>}
+
+      <label>
+        Breed
+        <input type="text" value={breed} onChange={(e) => setBreed(e.target.value)} />
+      </label>
+      {displayErrors.breed && <p>{displayErrors.breed}</p>}
+
+      <label>
+        Date of Birth
+        <input type="text" value={dateOfBirth} onChange={(e) => setDateOfBirth(e.target.value)} />
+      </label>
+      {displayErrors.dateOfBirth && <p>{displayErrors.dateOfBirth}</p>}
+
+      <label>
+        Sex
+        <select value={sex} onChange={(e) => setSex(e.target.value)}>
+          <option value="">Select</option>
+          <option value="Male">Male</option>
+          <option value="Female">Female</option>
+        </select>
+      </label>
+      {displayErrors.sex && <p>{displayErrors.sex}</p>}
+
+      <button type="submit" disabled={isSubmitting}>Register</button>
+    </form>
+  );
+}

--- a/frontend/test/api/registerDog.test.ts
+++ b/frontend/test/api/registerDog.test.ts
@@ -1,0 +1,72 @@
+import { registerDog } from '@/api/registerDog';
+
+const validData = {
+  name: 'Buddy',
+  breed: 'Golden Retriever',
+  dateOfBirth: '2023-06-15',
+  sex: 'Male',
+};
+
+describe('registerDog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a POST request to /api/dogs/register', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    global.fetch = fetchMock;
+
+    const result = await registerDog(validData);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/dogs/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validData),
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('returns failure with errors when the response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({
+        errors: { name: 'Name is required' },
+      }),
+    });
+
+    const result = await registerDog(validData);
+
+    expect(result).toEqual({
+      success: false,
+      errors: { name: 'Name is required' },
+    });
+  });
+
+  it('returns failure with a network error when fetch throws', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await registerDog(validData);
+
+    expect(result).toEqual({
+      success: false,
+      errors: { form: 'A network error occurred. Please try again.' },
+    });
+  });
+
+  it('returns failure with a generic error when the error response is not JSON', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    });
+
+    const result = await registerDog(validData);
+
+    expect(result).toEqual({
+      success: false,
+      errors: { form: 'An unexpected error occurred. Please try again.' },
+    });
+  });
+});

--- a/frontend/test/app/dogs/register/RegisterDogPage.test.tsx
+++ b/frontend/test/app/dogs/register/RegisterDogPage.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RegisterDogPage from '@/app/dogs/register/page';
+import { registerDog } from '@/api/registerDog';
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('@/api/registerDog', () => ({
+  registerDog: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/name/i), 'Buddy');
+  await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+  await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+  await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+}
+
+async function fillAndSubmitForm(user: ReturnType<typeof userEvent.setup>) {
+  await fillForm(user);
+  await user.click(screen.getByRole('button', { name: /register/i }));
+}
+
+describe('Register Dog Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the register dog form', () => {
+    render(<RegisterDogPage />);
+
+    expect(
+      screen.getByRole('heading', { name: /register dog/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls registerDog API when the form is submitted', async () => {
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(registerDog).toHaveBeenCalledWith({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+  }, 10000);
+
+  it('navigates to success route after successful registration', async () => {
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(pushMock).toHaveBeenCalledWith('/dogs/register/success');
+  }, 10000);
+
+  it('displays validation errors returned by the API', async () => {
+    vi.mocked(registerDog).mockResolvedValueOnce({
+      success: false,
+      errors: {
+        name: 'Name is required',
+        breed: 'Breed is required',
+      },
+    });
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText('Breed is required')).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('disables the submit button while the API call is in flight', async () => {
+    let resolveApi!: (value: { success: boolean }) => void;
+    vi.mocked(registerDog).mockImplementationOnce(
+      () => new Promise(resolve => { resolveApi = resolve; })
+    );
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillForm(user);
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByRole('button', { name: /register/i })).toBeDisabled();
+
+    resolveApi({ success: true });
+
+    await screen.findByRole('button', { name: /register/i });
+  }, 10000);
+
+  it('displays a form-level error when the API returns a network error', async () => {
+    vi.mocked(registerDog).mockResolvedValueOnce({
+      success: false,
+      errors: { form: 'A network error occurred. Please try again.' },
+    });
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(
+      await screen.findByText('A network error occurred. Please try again.')
+    ).toBeInTheDocument();
+  }, 10000);
+});

--- a/frontend/test/app/dogs/register/success/SuccessPage.test.tsx
+++ b/frontend/test/app/dogs/register/success/SuccessPage.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import SuccessPage from '@/app/dogs/register/success/page';
+
+describe('Register Dog Success Page', () => {
+  it('renders a success confirmation message', () => {
+    render(<SuccessPage />);
+
+    expect(
+      screen.getByRole('heading', { name: /registration successful/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/test/components/RegisterDogForm.test.tsx
+++ b/frontend/test/components/RegisterDogForm.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RegisterDogForm } from '@/components/RegisterDogForm';
+
+describe('RegisterDogForm', () => {
+  it('renders the form with all fields and a submit button', () => {
+    render(<RegisterDogForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/breed/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/date of birth/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sex/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /register/i })).toBeInTheDocument();
+  });
+
+  it('calls onSubmit with form data when all fields are filled', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+  }, 10000);
+
+  it('renders validation errors passed via errors prop', () => {
+    render(
+      <RegisterDogForm
+        onSubmit={vi.fn()}
+        errors={{ name: 'Name is already taken' }}
+      />
+    );
+
+    expect(screen.getByText('Name is already taken')).toBeInTheDocument();
+  });
+
+  it('shows error when name is empty', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('shows error when breed is empty', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('Breed is required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('shows error when date of birth is empty', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('Date of birth is required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('shows error when sex is not selected', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('Sex is required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('does not call onSubmit when validation fails', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('calls onSubmit after correcting validation errors', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RegisterDogForm onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: /register/i }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+  }, 10000);
+});

--- a/frontend/test/integration/RegisterDog.integration.test.tsx
+++ b/frontend/test/integration/RegisterDog.integration.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RegisterDogPage from '@/app/dogs/register/page';
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+async function fillAndSubmitForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/name/i), 'Buddy');
+  await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+  await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+  await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+  await user.click(screen.getByRole('button', { name: /register/i }));
+}
+
+describe('Register Dog (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('submits through the real API client and navigates on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/dogs/register/success');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/dogs/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        dateOfBirth: '2023-06-15',
+        sex: 'Male',
+      }),
+    });
+  });
+
+  it('displays server validation errors without navigating', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({
+        errors: { name: 'Name is already taken' },
+      }),
+    }));
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(await screen.findByText('Name is already taken')).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('displays a network error when the server is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const user = userEvent.setup();
+    render(<RegisterDogPage />);
+
+    await fillAndSubmitForm(user);
+
+    expect(
+      await screen.findByText('A network error occurred. Please try again.')
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   plugins: [tsconfigPaths(), react()] as any,
   test: {
+    testTimeout: 15000,
     projects: [
       {
         extends: true,
@@ -13,7 +14,7 @@ export default defineConfig({
           name: 'unit',
           environment: 'node',
           globals: true,
-          include: ['./test/lib/**/*.test.ts'],
+          include: ['./test/lib/**/*.test.ts', './test/api/**/*.test.ts'],
         },
       },
       {
@@ -24,6 +25,16 @@ export default defineConfig({
           globals: true,
           setupFiles: ['./test/setup.ts'],
           include: ['./test/app/**/*.test.{ts,tsx}', './test/components/**/*.test.{ts,tsx}'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'integration',
+          environment: 'jsdom',
+          globals: true,
+          setupFiles: ['./test/setup.ts'],
+          include: ['./test/integration/**/*.test.{ts,tsx}'],
         },
       },
     ],

--- a/product/stories/customer/US-084-register-dog-page.md
+++ b/product/stories/customer/US-084-register-dog-page.md
@@ -1,46 +1,74 @@
-# US-084 — Register Dog Page
+---
+id: US-084
+title: "Register Dog Page"
+epic: Customer
+milestone: M1+
+status: in-progress
+sprint: S4
+sprint_order: 6
+domain: customer
+vertical_slice: true
+dependencies:
+  - US-056
+  - US-102
+  - US-103
+replaces: "Frontend Testing Setup (completed, moved to US-103)"
+---
 
-## Intent
+# US-084: Register Dog Page
 
-As a **customer**, I want to register a new dog by filling out a form with my dog's details, so that the dog is added to my profile.
+## User Story
 
-## Value
-
-This is the first feature that lets a customer interact with the system beyond account creation. Registering a dog is the core action that makes Camp Fit Fur Dogs useful — without it, the product has no purpose. This story is also the **proving slice** for Sprint 4: the first vertical slice that includes a UI layer, exercising React form through API to database with TDD at every layer.
+As a **customer**, I can register a new dog by filling out a form with my dog's details, so that the dog is added to my profile.
 
 ## Acceptance Criteria
 
-- [ ] React form component with fields: dog name, breed, date of birth, sex.
-- [ ] Client-side validation for required fields and data types.
-- [ ] Form submits to the existing RegisterDog API endpoint via the typed API client (US-102).
-- [ ] Success feedback displayed after successful registration.
-- [ ] Validation errors, API errors, and network errors displayed to the user.
-- [ ] `customerId` passed as route parameter or prop (design seam for future auth).
-- [ ] Component tests cover render, validation, submission, and error states.
-- [ ] Integration test covers form → API client → mock server → success/error.
+- [ ] React form component with fields: dog name, breed, date of birth, sex
+- [ ] Client-side validation (required fields, data types)
+- [ ] Form submits to the existing RegisterDog API endpoint via the typed API client (US-102)
+- [ ] Success feedback displayed after successful registration
+- [ ] Error handling: validation errors, API errors, network errors displayed to user
+- [x] ~~customerId passed as route parameter or prop~~ → **Dropped (April 15).** See *Design Seam* below.
+- [ ] Component tests: render, validate, submit, error states
+- [ ] Integration test: form → API client → mock server → success/error
+- [ ] **Design Doc:** This slice is the living example — the code IS the documentation
 
-## Emotional Guarantees
+## TDD Requirements
 
-- **EG-01 Calm Confidence** — The form uses clear labels, no countdown timers, and no urgency language. The customer can take their time.
-- **EG-03 Graceful Recovery** — Validation errors appear inline next to the field with a suggestion for correction. API errors display a clear message with a path forward (retry or contact support).
-- **EG-05 Joyful Moments** — Successful registration includes a warm confirmation acknowledging the new dog by name.
-- **EG-06 Transparent Progress** — The form clearly indicates required fields and submission state (idle, submitting, success, error).
+**Heavy — first full-stack frontend TDD.** Red-green-refactor at every layer:
 
-## Edge Cases
+- [ ] Component renders correctly
+- [ ] Validation rejects invalid input
+- [ ] Successful submission calls API and shows feedback
+- [ ] Error states render correctly
 
-- What happens when the API is unreachable? → Network error displayed with retry option.
-- What happens when the customer submits a duplicate dog name? → API returns validation error; form displays it inline.
-- What happens when the customer navigates away mid-form? → Design seam for EG-04 (Forgiveness) in a future story; not in scope for Sprint 4.
-- What happens when `customerId` is missing or invalid? → Clear error message; form does not render without a valid customer context.
+## Design Seam: Customer Identity
+
+> **Original AC (dropped):** "customerId passed as route parameter or prop (design seam for future auth)"
+>
+> **Why it was dropped (April 15):** A customer registers *their own* dog — their identity comes from their authenticated session, not from the client. Exposing an owner ID in the route or request body is a security risk (path/body manipulation → registering dogs under another customer). A staff-managed registration flow would be a separate story with its own authorization model.
+
+### ICurrentUserService
+
+The backend introduces an `ICurrentUserService` abstraction to decouple identity resolution from the endpoint:
+
+- **Interface (`ICurrentUserService`):** Application layer. Single method returning the current user's identity.
+- **`DummyCurrentUserService`:** Infrastructure layer. Returns a hardcoded placeholder identity for Sprint 4 (pre-auth).
+- **When auth lands:** Swap `DummyCurrentUserService` for a real implementation that reads identity from the session/token. No endpoint or handler changes required.
+
+### Contract Changes
+
+- **Backend:** Create a `RegisterDogRequest` DTO with only `Name`, `Breed`, `DateOfBirth`, `Sex` — no `OwnerId`. The endpoint injects `ICurrentUserService`, reads the current user's identity, and constructs the full `RegisterDogCommand`.
+- **Frontend:** Remove `customerId` from the form data, API client payload, and all tests. The client never sends identity — the server owns it.
 
 ## Notes
 
-- Backend RegisterDog endpoint already exists from Sprint 3.
-- Uses the typed API client from US-102 (not raw fetch).
-- Test infrastructure from US-103 must be in place before TDD can begin.
-- `customerId` is a route parameter today; becomes session/token-derived when auth lands. The form, validation, API client call, handler, domain logic, and tests all stay the same.
-- **Demo sentence:** Navigate to a customer's page, click 'Add Dog', fill in name/breed/date of birth/sex, submit — see the dog in the database.
+- This is the **proving slice** for Sprint 4 — the entire sprint builds toward this story
+- Original US-084 content (Frontend Testing Setup) has been completed and moved to US-103
+- Form fields match the RegisterDogCommand backend contract (US-028): Name, Breed, DateOfBirth, Sex
+- **Demo:** Navigate to the register dog page, fill in name/breed/date of birth/sex, submit — see the dog in the database
 
 ## AC Revision History
 
-- **April 14, 2026:** Form fields updated from `name, breed, weight, notes` to `name, breed, dateOfBirth, sex` to match the `RegisterDogCommand` backend contract (US-028).
+- **April 14:** Form fields updated from name, breed, weight, notes to name, breed, dateOfBirth, sex to match the RegisterDogCommand backend contract (US-028)
+- **April 15:** AC 6 (customerId as route param) dropped. Customer identity must not come from the client. Introduced `ICurrentUserService` abstraction — `DummyCurrentUserService` pre-auth, real implementation post-auth. Backend needs `RegisterDogRequest` DTO excluding `OwnerId`. Frontend removes `customerId` from the entire chain.

--- a/src/CampFitFurDogs.Api/Dogs/RegisterDogEndpoint.cs
+++ b/src/CampFitFurDogs.Api/Dogs/RegisterDogEndpoint.cs
@@ -8,20 +8,25 @@ public static class RegisterDogEndpoint
     public static void MapRegisterDog(this IEndpointRouteBuilder app)
     {
         app.MapPost("/", async (
-            RegisterDogCommand cmd,
+            RegisterDogRequest request,
+            ICurrentUserService currentUserService,
             ICommandDispatcher dispatcher) =>
         {
             try
             {
-                var id = await dispatcher.Dispatch(cmd, CancellationToken.None);
+                var command = new RegisterDogCommand(
+                    currentUserService.GetCurrentUserId(),
+                    request.Name,
+                    request.Breed,
+                    request.DateOfBirth,
+                    request.Sex);
+
+                var id = await dispatcher.Dispatch(command, CancellationToken.None);
                 return Results.Created($"/api/dogs/{id}", new { DogId = id });
             }
             catch (ArgumentException ex)
             {
-                return Results.BadRequest(new
-                {
-                    Error = ex.Message.Split(" (Parameter")[0]
-                });
+                return Results.BadRequest(new { Error = ex.Message.Split(" (Parameter")[0] });
             }
         });
     }

--- a/src/CampFitFurDogs.Api/Dogs/RegisterDogRequest.cs
+++ b/src/CampFitFurDogs.Api/Dogs/RegisterDogRequest.cs
@@ -1,0 +1,7 @@
+namespace CampFitFurDogs.Api.Dogs;
+
+public sealed record RegisterDogRequest(
+    string Name,
+    string Breed,
+    DateOnly DateOfBirth,
+    string Sex);

--- a/src/CampFitFurDogs.Application/Abstractions/ICurrentUserService.cs
+++ b/src/CampFitFurDogs.Application/Abstractions/ICurrentUserService.cs
@@ -1,0 +1,6 @@
+namespace CampFitFurDogs.Application.Abstractions;
+
+public interface ICurrentUserService
+{
+    Guid GetCurrentUserId();
+}

--- a/src/CampFitFurDogs.Infrastructure/DependencyInjection.cs
+++ b/src/CampFitFurDogs.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using CampFitFurDogs.Domain.Dogs;
 using CampFitFurDogs.Infrastructure.Customers;
 using CampFitFurDogs.Infrastructure.Data;
 using CampFitFurDogs.Infrastructure.Dogs;
+using CampFitFurDogs.Application.Abstractions;
 
 namespace CampFitFurDogs.Infrastructure;
 
@@ -22,6 +23,7 @@ public static class DependencyInjection
 
         services.AddScoped<ICustomerRepository, CustomerRepository>();
         services.AddScoped<IDogRepository, DogRepository>();
+        services.AddSingleton<ICurrentUserService, DummyCurrentUserService>();
 
         return services;
     }

--- a/src/CampFitFurDogs.Infrastructure/DummyCurrentUserService.cs
+++ b/src/CampFitFurDogs.Infrastructure/DummyCurrentUserService.cs
@@ -2,7 +2,7 @@ using CampFitFurDogs.Application.Abstractions;
 
 namespace CampFitFurDogs.Infrastructure;
 
-public class DummyCurrentUserService : ICurrentUserService
+public sealed class DummyCurrentUserService : ICurrentUserService
 {
     // Hardcoded placeholder for Sprint 4 (pre-auth).
     // Swap for a real implementation when authentication lands.

--- a/src/CampFitFurDogs.Infrastructure/DummyCurrentUserService.cs
+++ b/src/CampFitFurDogs.Infrastructure/DummyCurrentUserService.cs
@@ -1,0 +1,13 @@
+using CampFitFurDogs.Application.Abstractions;
+
+namespace CampFitFurDogs.Infrastructure;
+
+public class DummyCurrentUserService : ICurrentUserService
+{
+    // Hardcoded placeholder for Sprint 4 (pre-auth).
+    // Swap for a real implementation when authentication lands.
+    private static readonly Guid PlaceholderId =
+        Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    public Guid GetCurrentUserId() => PlaceholderId;
+}

--- a/tests/CampFitFurDogs.Api.Tests/ApiTestHelpers.cs
+++ b/tests/CampFitFurDogs.Api.Tests/ApiTestHelpers.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace CampFitFurDogs.Api.Tests;
+
+public static class ApiTestHelpers
+{
+    public sealed record OwnerResponse(Guid CustomerId);
+    public sealed record RegisterDogResponse(Guid DogId);
+
+    public static async Task<Guid> CreateOwnerAsync(HttpClient client)
+    {
+        var request = new
+        {
+            FirstName = "Frank",
+            LastName = "Hughes",
+            Email = $"owner-{Guid.NewGuid()}@example.com",
+            Phone = "555-1234",
+            Password = "SuperSecure123!"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/customers", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<OwnerResponse>();
+        return body!.CustomerId;
+    }
+
+    public static async Task<Guid> CreateAndSetOwnerAsync(
+        HttpClient client, TestCurrentUserService testUserService)
+    {
+        var ownerId = await CreateOwnerAsync(client);
+        testUserService.CurrentUserId = ownerId;
+        return ownerId;
+    }
+
+    public static async Task<Guid> RegisterDogAsync(
+        HttpClient client, TestCurrentUserService testUserService, Guid ownerId)
+    {
+        testUserService.CurrentUserId = ownerId;
+
+        var request = new
+        {
+            Name = "Biscuit",
+            Breed = "Golden Retriever",
+            DateOfBirth = "2022-06-15",
+            Sex = "Female"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/dogs", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<RegisterDogResponse>();
+        return body!.DogId;
+    }
+}

--- a/tests/CampFitFurDogs.Api.Tests/CampFitFurDogs.Api.Tests.csproj
+++ b/tests/CampFitFurDogs.Api.Tests/CampFitFurDogs.Api.Tests.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CampFitFurDogs.Api\CampFitFurDogs.Api.csproj" />
+    <ProjectReference Include="..\..\src\CampFitFurDogs.Application\CampFitFurDogs.Application.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/CampFitFurDogs.Api.Tests/CampFitFurDogsApiFactory.cs
+++ b/tests/CampFitFurDogs.Api.Tests/CampFitFurDogsApiFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Testcontainers.PostgreSql;
-
+using CampFitFurDogs.Application.Abstractions;
 using CampFitFurDogs.Infrastructure.Data;
 
 namespace CampFitFurDogs.Api.Tests;
@@ -12,6 +12,8 @@ public class CampFitFurDogsApiFactory : WebApplicationFactory<Program>, IAsyncLi
 {
     private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:17-alpine")
         .Build();
+
+    public TestCurrentUserService TestUserService { get; } = new();
 
     public async Task InitializeAsync()
     {
@@ -31,12 +33,17 @@ public class CampFitFurDogsApiFactory : WebApplicationFactory<Program>, IAsyncLi
             // Remove the app's Npgsql registration
             var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
-            if (descriptor != null)
-                services.Remove(descriptor);
+            if (descriptor != null) services.Remove(descriptor);
 
             // Point at the Testcontainers PostgreSQL instance
             services.AddDbContext<AppDbContext>(options =>
                 options.UseNpgsql(_postgres.GetConnectionString()));
+
+            // Override ICurrentUserService with test double
+            var userServiceDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(ICurrentUserService));
+            if (userServiceDescriptor != null) services.Remove(userServiceDescriptor);
+            services.AddSingleton<ICurrentUserService>(TestUserService);
 
             // Create schema from EF model
             var sp = services.BuildServiceProvider();

--- a/tests/CampFitFurDogs.Api.Tests/Dogs/GetDogProfileEndpointTests.cs
+++ b/tests/CampFitFurDogs.Api.Tests/Dogs/GetDogProfileEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using static CampFitFurDogs.Api.Tests.ApiTestHelpers;
 
 namespace CampFitFurDogs.Api.Tests.Dogs;
 
@@ -15,47 +16,6 @@ public class GetDogProfileEndpointTests : IClassFixture<CampFitFurDogsApiFactory
         _testUserService = factory.TestUserService;
     }
 
-    // ── Helpers ──
-
-    private async Task<Guid> CreateOwnerAsync()
-    {
-        var request = new
-        {
-            FirstName = "Frank",
-            LastName = "Hughes",
-            Email = $"owner-{Guid.NewGuid()}@example.com",
-            Phone = "555-1234",
-            Password = "SuperSecure123!"
-        };
-
-        var response = await _client.PostAsJsonAsync("/api/customers", request);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-
-        var body = await response.Content.ReadFromJsonAsync<OwnerResponse>();
-        return body!.CustomerId;
-    }
-
-    private async Task<Guid> RegisterDogAsync(Guid ownerId)
-    {
-        _testUserService.CurrentUserId = ownerId;
-
-        var request = new
-        {
-            Name = "Biscuit",
-            Breed = "Golden Retriever",
-            DateOfBirth = "2022-06-15",
-            Sex = "Female"
-        };
-
-        var response = await _client.PostAsJsonAsync("/api/dogs", request);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-
-        var body = await response.Content.ReadFromJsonAsync<RegisterDogResponse>();
-        return body!.DogId;
-    }
-
-    private sealed record OwnerResponse(Guid CustomerId);
-    private sealed record RegisterDogResponse(Guid DogId);
     private sealed record DogProfileResponse(
         Guid Id, Guid OwnerId, string Name, string Breed,
         DateOnly DateOfBirth, string Sex);
@@ -65,8 +25,8 @@ public class GetDogProfileEndpointTests : IClassFixture<CampFitFurDogsApiFactory
     [Fact]
     public async Task GetDogProfile_ExistingDogOwnedByCustomer_Returns200WithProfile()
     {
-        var ownerId = await CreateOwnerAsync();
-        var dogId = await RegisterDogAsync(ownerId);
+        var ownerId = await CreateOwnerAsync(_client);
+        var dogId = await RegisterDogAsync(_client, _testUserService, ownerId);
 
         var response = await _client.GetAsync($"/api/dogs/{dogId}?customerId={ownerId}");
 
@@ -97,9 +57,9 @@ public class GetDogProfileEndpointTests : IClassFixture<CampFitFurDogsApiFactory
     [Fact]
     public async Task GetDogProfile_DogNotOwnedByCustomer_Returns404()
     {
-        var ownerA = await CreateOwnerAsync();
-        var dogId = await RegisterDogAsync(ownerA);
-        var ownerB = await CreateOwnerAsync();
+        var ownerA = await CreateOwnerAsync(_client);
+        var dogId = await RegisterDogAsync(_client, _testUserService, ownerA);
+        var ownerB = await CreateOwnerAsync(_client);
 
         var response = await _client.GetAsync(
             $"/api/dogs/{dogId}?customerId={ownerB}");

--- a/tests/CampFitFurDogs.Api.Tests/Dogs/GetDogProfileEndpointTests.cs
+++ b/tests/CampFitFurDogs.Api.Tests/Dogs/GetDogProfileEndpointTests.cs
@@ -7,10 +7,12 @@ namespace CampFitFurDogs.Api.Tests.Dogs;
 public class GetDogProfileEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
 {
     private readonly HttpClient _client;
+    private readonly TestCurrentUserService _testUserService;
 
     public GetDogProfileEndpointTests(CampFitFurDogsApiFactory factory)
     {
         _client = factory.CreateClient();
+        _testUserService = factory.TestUserService;
     }
 
     // ── Helpers ──
@@ -35,9 +37,10 @@ public class GetDogProfileEndpointTests : IClassFixture<CampFitFurDogsApiFactory
 
     private async Task<Guid> RegisterDogAsync(Guid ownerId)
     {
+        _testUserService.CurrentUserId = ownerId;
+
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Biscuit",
             Breed = "Golden Retriever",
             DateOfBirth = "2022-06-15",

--- a/tests/CampFitFurDogs.Api.Tests/Dogs/RegisterDogEndpointTests.cs
+++ b/tests/CampFitFurDogs.Api.Tests/Dogs/RegisterDogEndpointTests.cs
@@ -7,15 +7,17 @@ namespace CampFitFurDogs.Api.Tests.Dogs;
 public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
 {
     private readonly HttpClient _client;
+    private readonly TestCurrentUserService _testUserService;
 
     public RegisterDogEndpointTests(CampFitFurDogsApiFactory factory)
     {
         _client = factory.CreateClient();
+        _testUserService = factory.TestUserService;
     }
 
-    // ── Helper: create a customer so we have a valid OwnerId ──
+    // ── Helper: create a customer and set as current user ──
 
-    private async Task<Guid> CreateOwnerAsync()
+    private async Task<Guid> CreateAndSetOwnerAsync()
     {
         var request = new
         {
@@ -30,7 +32,9 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var body = await response.Content.ReadFromJsonAsync<OwnerResponse>();
-        return body!.CustomerId;
+        var ownerId = body!.CustomerId;
+        _testUserService.CurrentUserId = ownerId;
+        return ownerId;
     }
 
     private sealed record OwnerResponse(Guid CustomerId);
@@ -41,11 +45,10 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_ShouldReturn201AndDogId()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Biscuit",
             Breed = "Golden Retriever",
             DateOfBirth = "2022-06-15",
@@ -55,7 +58,6 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         var response = await _client.PostAsJsonAsync("/api/dogs", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-
         var body = await response.Content.ReadFromJsonAsync<RegisterDogResponse>();
         body.Should().NotBeNull();
         body!.DogId.Should().NotBe(Guid.Empty);
@@ -64,11 +66,10 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_ShouldHaveLocationHeader()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Maple",
             Breed = "Poodle",
             DateOfBirth = "2023-03-10",
@@ -87,11 +88,10 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_WithEmptyName_Returns400()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "",
             Breed = "Labrador",
             DateOfBirth = "2021-01-01",
@@ -99,18 +99,16 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         };
 
         var response = await _client.PostAsJsonAsync("/api/dogs", request);
-
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task RegisterDog_WithEmptyBreed_Returns400()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Biscuit",
             Breed = "",
             DateOfBirth = "2021-01-01",
@@ -118,18 +116,16 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         };
 
         var response = await _client.PostAsJsonAsync("/api/dogs", request);
-
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task RegisterDog_WithInvalidSex_Returns400()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Biscuit",
             Breed = "Poodle",
             DateOfBirth = "2023-01-01",
@@ -137,7 +133,6 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         };
 
         var response = await _client.PostAsJsonAsync("/api/dogs", request);
-
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -146,11 +141,10 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_SuccessResponse_DoesNotExposeInternals()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "Biscuit",
             Breed = "Beagle",
             DateOfBirth = "2022-08-20",
@@ -168,11 +162,10 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_ErrorResponse_DoesNotExposeInternals()
     {
-        var ownerId = await CreateOwnerAsync();
+        await CreateAndSetOwnerAsync();
 
         var request = new
         {
-            OwnerId = ownerId,
             Name = "",
             Breed = "Beagle",
             DateOfBirth = "2022-08-20",
@@ -186,5 +179,28 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         body.Should().NotContainEquivalentOf("innerException");
         body.Should().NotContainEquivalentOf("ArgumentException");
         body.Should().NotContainEquivalentOf("NullReferenceException");
+    }
+
+    // ── ICurrentUserService: no OwnerId in request body ──
+
+    [Fact]
+    public async Task RegisterDog_WithoutOwnerId_ShouldReturn201_WhenIdentityFromServer()
+    {
+        await CreateAndSetOwnerAsync();
+
+        var request = new
+        {
+            Name = "ServerIdentityDog",
+            Breed = "Golden Retriever",
+            DateOfBirth = "2022-06-15",
+            Sex = "Female"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/dogs", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<RegisterDogResponse>();
+        body.Should().NotBeNull();
+        body!.DogId.Should().NotBe(Guid.Empty);
     }
 }

--- a/tests/CampFitFurDogs.Api.Tests/Dogs/RegisterDogEndpointTests.cs
+++ b/tests/CampFitFurDogs.Api.Tests/Dogs/RegisterDogEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using static CampFitFurDogs.Api.Tests.ApiTestHelpers;
 
 namespace CampFitFurDogs.Api.Tests.Dogs;
 
@@ -15,37 +16,12 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         _testUserService = factory.TestUserService;
     }
 
-    // ── Helper: create a customer and set as current user ──
-
-    private async Task<Guid> CreateAndSetOwnerAsync()
-    {
-        var request = new
-        {
-            FirstName = "Frank",
-            LastName = "Hughes",
-            Email = $"owner-{Guid.NewGuid()}@example.com",
-            Phone = "555-1234",
-            Password = "SuperSecure123!"
-        };
-
-        var response = await _client.PostAsJsonAsync("/api/customers", request);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-
-        var body = await response.Content.ReadFromJsonAsync<OwnerResponse>();
-        var ownerId = body!.CustomerId;
-        _testUserService.CurrentUserId = ownerId;
-        return ownerId;
-    }
-
-    private sealed record OwnerResponse(Guid CustomerId);
-    private sealed record RegisterDogResponse(Guid DogId);
-
     // ── AC: Successful registration ──
 
     [Fact]
     public async Task RegisterDog_ShouldReturn201AndDogId()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -66,7 +42,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_ShouldHaveLocationHeader()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -88,7 +64,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_WithEmptyName_Returns400()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -105,7 +81,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_WithEmptyBreed_Returns400()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -122,7 +98,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_WithInvalidSex_Returns400()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -141,7 +117,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_SuccessResponse_DoesNotExposeInternals()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -162,7 +138,7 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
     [Fact]
     public async Task RegisterDog_ErrorResponse_DoesNotExposeInternals()
     {
-        await CreateAndSetOwnerAsync();
+        await CreateAndSetOwnerAsync(_client, _testUserService);
 
         var request = new
         {
@@ -179,28 +155,5 @@ public class RegisterDogEndpointTests : IClassFixture<CampFitFurDogsApiFactory>
         body.Should().NotContainEquivalentOf("innerException");
         body.Should().NotContainEquivalentOf("ArgumentException");
         body.Should().NotContainEquivalentOf("NullReferenceException");
-    }
-
-    // ── ICurrentUserService: no OwnerId in request body ──
-
-    [Fact]
-    public async Task RegisterDog_WithoutOwnerId_ShouldReturn201_WhenIdentityFromServer()
-    {
-        await CreateAndSetOwnerAsync();
-
-        var request = new
-        {
-            Name = "ServerIdentityDog",
-            Breed = "Golden Retriever",
-            DateOfBirth = "2022-06-15",
-            Sex = "Female"
-        };
-
-        var response = await _client.PostAsJsonAsync("/api/dogs", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var body = await response.Content.ReadFromJsonAsync<RegisterDogResponse>();
-        body.Should().NotBeNull();
-        body!.DogId.Should().NotBe(Guid.Empty);
     }
 }

--- a/tests/CampFitFurDogs.Api.Tests/TestCurrentUserService.cs
+++ b/tests/CampFitFurDogs.Api.Tests/TestCurrentUserService.cs
@@ -1,0 +1,9 @@
+using CampFitFurDogs.Application.Abstractions;
+
+namespace CampFitFurDogs.Api.Tests;
+
+public class TestCurrentUserService : ICurrentUserService
+{
+    public Guid CurrentUserId { get; set; } = Guid.NewGuid();
+    public Guid GetCurrentUserId() => CurrentUserId;
+}

--- a/tests/CampFitFurDogs.Api.Tests/TestCurrentUserService.cs
+++ b/tests/CampFitFurDogs.Api.Tests/TestCurrentUserService.cs
@@ -2,7 +2,7 @@ using CampFitFurDogs.Application.Abstractions;
 
 namespace CampFitFurDogs.Api.Tests;
 
-public class TestCurrentUserService : ICurrentUserService
+public sealed class TestCurrentUserService : ICurrentUserService
 {
     public Guid CurrentUserId { get; set; } = Guid.NewGuid();
     public Guid GetCurrentUserId() => CurrentUserId;


### PR DESCRIPTION
## Summary

Introduce `ICurrentUserService` abstraction so the Register Dog endpoint resolves owner identity server-side instead of accepting `OwnerId` in the request body. Pre-auth placeholder (`DummyCurrentUserService`) ships now; real implementation swaps in when authentication lands.

Closes #118

## Changes

- Add `ICurrentUserService` abstraction (Application layer)
- Add `RegisterDogRequest` DTO — API contract no longer includes `OwnerId`
- Endpoint binds DTO + injects `ICurrentUserService` to build `RegisterDogCommand`
- Add `DummyCurrentUserService` placeholder (Infrastructure, `Singleton`)
- Register `ICurrentUserService` in Infrastructure DI
- Add `TestCurrentUserService` test double + factory wiring
- Extract `ApiTestHelpers` — shared records and owner/dog creation helpers
- Seal `DummyCurrentUserService` and `TestCurrentUserService`
- Remove redundant test (was identical to `RegisterDog_ShouldReturn201AndDogId` post-refactor)
- 92/92 tests green

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed