### PR TITLE
chore: mark US-051 and US-055 ADRs as done

### DIFF
--- a/product/stories/docs/US-051-adr-cqrs-pipelines.md
+++ b/product/stories/docs/US-051-adr-cqrs-pipelines.md
@@ -15,11 +15,11 @@ The codebase uses a command/query separation pattern with handler dispatch. Befo
 
 ## Acceptance Criteria
 
-- [ ] ADR created in `docs/adr/` following the existing ADR template.
-- [ ] Documents the command/query separation pattern used in the codebase.
-- [ ] Documents pipeline behavior (validation, logging, transaction) approach.
-- [ ] Documents handler discovery and dispatch mechanism.
-- [ ] ADR index (`docs/adr/README.md`) updated with the new entry.
+- [x] ADR created in `docs/adr/` following the existing ADR template.
+- [x] Documents the command/query separation pattern used in the codebase.
+- [x] Documents pipeline behavior (validation, logging, transaction) approach.
+- [x] Documents handler discovery and dispatch mechanism.
+- [x] ADR index (`docs/adr/README.md`) updated with the new entry.
 
 ## Dependencies
 

--- a/product/stories/docs/US-055-adr-react-nextjs.md
+++ b/product/stories/docs/US-055-adr-react-nextjs.md
@@ -15,11 +15,11 @@ The team has informally decided on React with Next.js and TypeScript for the fro
 
 ## Acceptance Criteria
 
-- [ ] ADR-0012 created in `docs/adr/` following the existing ADR template.
-- [ ] Documents the decision to use React with Next.js and TypeScript.
-- [ ] Captures alternatives considered (e.g., Blazor, Angular, Vue).
-- [ ] Documents consequences: build tooling, deployment model, API integration approach.
-- [ ] ADR index (`docs/adr/README.md`) updated with the new entry.
+- [x] ADR-0012 created in `docs/adr/` following the existing ADR template.
+- [x] Documents the decision to use React with Next.js and TypeScript.
+- [x] Captures alternatives considered (e.g., Blazor, Angular, Vue).
+- [x] Documents consequences: build tooling, deployment model, API integration approach.
+- [x] ADR index (`docs/adr/README.md`) updated with the new entry.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Sprint 4 housekeeping — marks US-051 (ADR CQRS Pipelines) and US-055
(ADR React/Next.js) as complete. ADR-0011 shipped via PR #126 and
ADR-0012 shipped via PR #125; this PR ticks the acceptance criteria
checkboxes in both story files.

## Changes

- US-051: ticked all 5 AC checkboxes (ADR-0011 on main)
- US-055: ticked all 5 AC checkboxes (ADR-0012 on main)

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed