### PR TITLE
feat(US-050): Unit of Work pattern

### DIFF
--- a/docs/adr/0017-unit-of-work-pattern.md
+++ b/docs/adr/0017-unit-of-work-pattern.md
@@ -1,0 +1,27 @@
+# ADR-0017: Unit of Work Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+Prior to this change, each repository called `SaveChangesAsync` after its own `AddAsync`. This meant:
+
+- No transactional boundary — if a handler called two repositories, each persisted independently.
+- Repositories had persistence side-effects, violating the collection-abstraction intent of DDD repositories.
+- Testing persistence behavior required mocking `SaveChangesAsync` inside each fake repository.
+
+## Decision
+
+Introduce an `IUnitOfWork` interface (`CommitAsync`) in the Application.Abstractions layer. Handlers call it once after all repository operations. Repositories become pure in-memory collection facades — they stage changes on the `DbContext` change tracker but never flush to the database.
+
+`EfUnitOfWork` in Infrastructure delegates to `AppDbContext.SaveChangesAsync`, giving the handler explicit control over the transactional boundary.
+
+## Consequences
+
+- **Handlers own persistence.** Every command handler ends with `await _unitOfWork.CommitAsync(ct)`.
+- **Repos are side-effect-free.** Easier to reason about, easier to fake.
+- **Infrastructure tests must call `SaveChangesAsync` directly** when testing repo behavior outside of a handler.
+- **DI registration is explicit.** `EfUnitOfWork` doesn't match Scrutor's suffix scan (`Repository`, `Service`, `Provider`), so it's registered manually with `AddScoped`.
+- **Future benefit:** cross-aggregate operations in a single handler automatically share a transaction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,5 @@ New ADRs should follow [TEMPLATE.md](TEMPLATE.md).
 | [0013](0013-server-side-identity-resolution.md) | Identity Resolution for ICurrentUserService | Accepted |
 | [0014](0014-dispatcher-pipeline.md) | Application Dispatcher Pipeline | Accepted |
 | [0015](0015-convention-based-auto-registration.md) | Convention-Based Auto-Registration | Accepted |
+| [0017](0017-unit-of-work-pattern.md) | Unit of Work Pattern | Accepted |
+| [0015](0015-convention-based-auto-registration.md) | Convention-Based Auto-Registration | Accepted |

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -95,6 +95,7 @@ See:
 - **Abstractions Contract** — `developer/abstractions-contract.md`
 - **Dispatcher Pipeline** — `developer/dispatcher-pipeline.md`
 - **API Endpoint Purity** — `developer/api-endpoint-purity.md`
+- **DI Conventions** — `developer/di-conventions.md`
 
 ### 4.2 Domain Modeling
 

--- a/docs/guides/developer/abstractions-contract.md
+++ b/docs/guides/developer/abstractions-contract.md
@@ -17,6 +17,7 @@ These include:
 - **Service interfaces** (e.g., `ICurrentUserService`)
 - **Dispatcher interfaces** (`ICommandDispatcher`, `IQueryDispatcher`)
 - **Domain event abstractions** (`IDomainEventDispatcher`, `IDomainEventHandler<T>`)
+- **Cross-cutting interfaces** (e.g., `IUnitOfWork`)
 
 Everything in Abstractions is intentionally stable and dependency‑safe.
 
@@ -42,6 +43,7 @@ src/CampFitFurDogs.Application/Abstractions/
   ICurrentUserService.cs
   IDomainEventDispatcher.cs
   IDomainEventHandler.cs
+  IUnitOfWork.cs
 ```
 
 Each feature has its own subfolder.

--- a/docs/guides/developer/di-conventions.md
+++ b/docs/guides/developer/di-conventions.md
@@ -172,6 +172,8 @@ No slice‑specific types may be registered manually.
 
 If a contributor finds themselves editing DI code to add a handler, validator, or repository, the slice is violating conventions.
 
+**Exception — cross-cutting infrastructure types.** Types that serve all slices but do not match Scrutor's suffix scan (e.g., `EfUnitOfWork` implementing `IUnitOfWork`) are registered explicitly in `Infrastructure/DependencyInjection.cs`. These are shared infrastructure, not slice-specific. See ADR-0017.
+
 ---
 
 # 7. Troubleshooting

--- a/docs/guides/developer/dispatcher-pipeline.md
+++ b/docs/guides/developer/dispatcher-pipeline.md
@@ -50,11 +50,16 @@ The command pipeline performs:
    - Resolve `ICommandHandler<TCommand, TResult>`.
    - Invoke `HandleAsync`.
 
-3. **Domain Events**  
+3. **Persistence (Unit of Work)**  
+   - Command handlers call `IUnitOfWork.CommitAsync` after all repository operations.
+   - Repositories stage changes on the DbContext change tracker but never flush.
+   - See ADR-0017.
+
+4. **Domain Events**  
    - Collect domain events from aggregates.
    - Dispatch via `IDomainEventDispatcher`.
 
-4. **Result**  
+5. **Result**  
    - Return the handler result to the caller.
 
 ---
@@ -136,6 +141,7 @@ When adding a new command or query:
 
 - Define the request type in Application Abstractions.
 - Implement a handler in the corresponding slice.
+- Inject `IUnitOfWork` into command handlers and call `CommitAsync` after repository operations.
 - Optionally add validators.
 - Use `ICommandDispatcher` / `IQueryDispatcher` from API endpoints.
 - Do not bypass the dispatcher pipeline.

--- a/docs/guides/developer/folder-structure.md
+++ b/docs/guides/developer/folder-structure.md
@@ -98,6 +98,7 @@ Each slice contains:
 - Contains handlers, validators, dispatchers.
 - Dispatches domain events.
 - Contains no HTTP or persistence logic.
+- Calls `IUnitOfWork.CommitAsync` to persist changes (command handlers only).
 
 ### 3.3 Domain Layer
 
@@ -199,11 +200,12 @@ When adding a new feature:
 2. Add handlers/validators to **Application**.
 3. Add domain entities/events to **Domain**.
 4. Add repositories to **Infrastructure**.
-5. Add endpoints to **Api**.
-6. Add tests to the corresponding test project.
-7. Follow naming conventions strictly.
-8. Do not bypass the dispatcher pipeline.
-9. Do not place code in SharedKernel unless it is truly cross-cutting.
+5. Inject `IUnitOfWork` in command handlers and call `CommitAsync` after repository operations.
+6. Add endpoints to **Api**.
+7. Add tests to the corresponding test project.
+8. Follow naming conventions strictly.
+9. Do not bypass the dispatcher pipeline.
+10. Do not place code in SharedKernel unless it is truly cross-cutting.
 
 If you’re unsure where something belongs, default to the **most restrictive** layer (Domain > Application > Infrastructure > Api).
 

--- a/docs/guides/developer/test-architecture.md
+++ b/docs/guides/developer/test-architecture.md
@@ -128,6 +128,7 @@ Handler tests should:
 - Test business logic in isolation.
 - Mock repositories or external services.
 - Avoid testing validation (that belongs to validator tests).
+- Inject `FakeUnitOfWork` alongside fake repositories. Assert `Committed` is `true` and verify `CommitCount` for commit behavior.
 
 ### 4.3 Validator Tests
 
@@ -185,6 +186,7 @@ When adding new features:
 - Add domain tests.
 - Add endpoint tests.
 - Ensure existing guardrails still pass.
+- Handler tests must verify `IUnitOfWork.CommitAsync` is called on the happy path and not called on validation/guard failures.
 
 When modifying existing architecture:
 

--- a/src/CampFitFurDogs.Application/Abstractions/IUnitOfWork.cs
+++ b/src/CampFitFurDogs.Application/Abstractions/IUnitOfWork.cs
@@ -1,0 +1,6 @@
+namespace CampFitFurDogs.Application.Abstractions;
+
+public interface IUnitOfWork
+{
+    Task<int> CommitAsync(CancellationToken ct = default);
+}

--- a/src/CampFitFurDogs.Application/Customers/CreateCustomer/CreateCustomerHandler.cs
+++ b/src/CampFitFurDogs.Application/Customers/CreateCustomer/CreateCustomerHandler.cs
@@ -1,3 +1,4 @@
+// src/CampFitFurDogs.Application/Customers/CreateCustomer/CreateCustomerHandler.cs
 using CampFitFurDogs.Application.Abstractions;
 using CampFitFurDogs.Application.Abstractions.Customers.CreateCustomer;
 using CampFitFurDogs.Domain.Customers;
@@ -8,16 +9,17 @@ public sealed class CreateCustomerHandler
     : ICommandHandler<CreateCustomerCommand, Guid>
 {
     private readonly ICustomerRepository _repo;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public CreateCustomerHandler(ICustomerRepository repo)
+    public CreateCustomerHandler(ICustomerRepository repo, IUnitOfWork unitOfWork)
     {
         _repo = repo;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<Guid> Handle(CreateCustomerCommand request, CancellationToken ct)
     {
         var email = Email.From(request.Email);
-
         if (await _repo.EmailExistsAsync(email, ct))
             throw new EmailAlreadyExistsException(email.Value);
 
@@ -32,12 +34,8 @@ public sealed class CreateCustomerHandler
             passwordHash);
 
         await _repo.AddAsync(customer, ct);
+        await _unitOfWork.CommitAsync(ct);
 
         return customer.Id.Value;
-    }
-
-    private static string HashPassword(string raw)
-    {
-        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(raw));
     }
 }

--- a/src/CampFitFurDogs.Application/Dogs/RegisterDog/RegisterDogHandler.cs
+++ b/src/CampFitFurDogs.Application/Dogs/RegisterDog/RegisterDogHandler.cs
@@ -8,10 +8,12 @@ namespace CampFitFurDogs.Application.Dogs.RegisterDog;
 public sealed class RegisterDogHandler : ICommandHandler<RegisterDogCommand, Guid>
 {
     private readonly IDogRepository _dogRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public RegisterDogHandler(IDogRepository dogRepository)
+    public RegisterDogHandler(IDogRepository dogRepository, IUnitOfWork unitOfWork)
     {
         _dogRepository = dogRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<Guid> Handle(RegisterDogCommand command, CancellationToken ct)
@@ -27,6 +29,7 @@ public sealed class RegisterDogHandler : ICommandHandler<RegisterDogCommand, Gui
         var dog = Dog.Create(ownerId, name, breed, dob, sex);
 
         await _dogRepository.AddAsync(dog, ct);
+        await _unitOfWork.CommitAsync(ct);
 
         return dog.Id.Value;
     }

--- a/src/CampFitFurDogs.Infrastructure/Customers/CustomerRepository.cs
+++ b/src/CampFitFurDogs.Infrastructure/Customers/CustomerRepository.cs
@@ -1,7 +1,6 @@
-using Microsoft.EntityFrameworkCore;
-
 using CampFitFurDogs.Domain.Customers;
 using CampFitFurDogs.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace CampFitFurDogs.Infrastructure.Customers;
 
@@ -16,13 +15,11 @@ public sealed class CustomerRepository : ICustomerRepository
 
     public async Task<bool> EmailExistsAsync(Email email, CancellationToken ct)
     {
-        return await _db.Customers
-            .AnyAsync(c => c.Email.Value == email.Value, ct);
+        return await _db.Customers.AnyAsync(c => c.Email == email, ct);
     }
 
     public async Task AddAsync(Customer customer, CancellationToken ct)
     {
         await _db.Customers.AddAsync(customer, ct);
-        await _db.SaveChangesAsync(ct);
     }
 }

--- a/src/CampFitFurDogs.Infrastructure/Customers/CustomerRepository.cs
+++ b/src/CampFitFurDogs.Infrastructure/Customers/CustomerRepository.cs
@@ -15,7 +15,7 @@ public sealed class CustomerRepository : ICustomerRepository
 
     public async Task<bool> EmailExistsAsync(Email email, CancellationToken ct)
     {
-        return await _db.Customers.AnyAsync(c => c.Email == email, ct);
+        return await _db.Customers.AnyAsync(c => c.Email.Value == email.Value, ct);
     }
 
     public async Task AddAsync(Customer customer, CancellationToken ct)

--- a/src/CampFitFurDogs.Infrastructure/Data/EfUnitOfWork.cs
+++ b/src/CampFitFurDogs.Infrastructure/Data/EfUnitOfWork.cs
@@ -1,0 +1,18 @@
+using CampFitFurDogs.Application.Abstractions;
+
+namespace CampFitFurDogs.Infrastructure.Data;
+
+public sealed class EfUnitOfWork : IUnitOfWork
+{
+    private readonly AppDbContext _db;
+
+    public EfUnitOfWork(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<int> CommitAsync(CancellationToken ct = default)
+    {
+        return _db.SaveChangesAsync(ct);
+    }
+}

--- a/src/CampFitFurDogs.Infrastructure/DependencyInjection.cs
+++ b/src/CampFitFurDogs.Infrastructure/DependencyInjection.cs
@@ -23,23 +23,26 @@ public static class DependencyInjection
         });
 
         // 2. Repositories, services, adapters, interceptors (Scrutor)
-services.Scan(scan => scan
-    .FromAssemblies(assembly)
+        services.Scan(scan => scan
+            .FromAssemblies(assembly)
 
-    .AddClasses(c => c.Where(type => type.Name.EndsWith("Repository")))
-        .AsImplementedInterfaces()
-        .WithScopedLifetime()
+            .AddClasses(c => c.Where(type => type.Name.EndsWith("Repository")))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime()
 
-    .AddClasses(c => c.Where(type => type.Name.EndsWith("Service")))
-        .AsImplementedInterfaces()
-        .WithScopedLifetime()
+            .AddClasses(c => c.Where(type => type.Name.EndsWith("Service")))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime()
 
-    .AddClasses(c => c.Where(type => type.Name.EndsWith("Provider")))
-        .AsImplementedInterfaces()
-        .WithScopedLifetime()
-);
+            .AddClasses(c => c.Where(type => type.Name.EndsWith("Provider")))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime()
+        );
 
-        // 3. Current user service (explicit)
+        // 3. Unit of Work (explicit — not matched by Scrutor suffixes)
+        services.AddScoped<IUnitOfWork, EfUnitOfWork>();
+
+        // 4. Current user service (explicit)
         services.AddSingleton<ICurrentUserService, DummyCurrentUserService>();
 
         return services;

--- a/src/CampFitFurDogs.Infrastructure/Dogs/DogRepository.cs
+++ b/src/CampFitFurDogs.Infrastructure/Dogs/DogRepository.cs
@@ -19,6 +19,6 @@ public sealed class DogRepository : IDogRepository
 
     public async Task<Dog?> GetByIdAsync(DogId id, CancellationToken cancellationToken = default)
     {
-        return await _db.Dogs.FindAsync([id, cancellationToken], cancellationToken);
+        return await _db.Dogs.FindAsync([id], cancellationToken);
     }
 }

--- a/src/CampFitFurDogs.Infrastructure/Dogs/DogRepository.cs
+++ b/src/CampFitFurDogs.Infrastructure/Dogs/DogRepository.cs
@@ -15,12 +15,10 @@ public sealed class DogRepository : IDogRepository
     public async Task AddAsync(Dog dog, CancellationToken cancellationToken = default)
     {
         await _db.Dogs.AddAsync(dog, cancellationToken);
-        await _db.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<Dog?> GetByIdAsync(DogId id, CancellationToken cancellationToken = default)
     {
         return await _db.Dogs.FindAsync([id, cancellationToken], cancellationToken);
     }
-
 }

--- a/tests/CampFitFurDogs.Application.Tests/Customers/CreateCustomer/CreateCustomerHandlerTests.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Customers/CreateCustomer/CreateCustomerHandlerTests.cs
@@ -1,0 +1,70 @@
+// tests/CampFitFurDogs.Application.Tests/Customers/CreateCustomer/CreateCustomerHandlerTests.cs
+using CampFitFurDogs.Application.Abstractions.Customers.CreateCustomer;
+using CampFitFurDogs.Application.Customers.CreateCustomer;
+using CampFitFurDogs.Application.Tests.Fakes;
+using CampFitFurDogs.Domain.Customers;
+
+namespace CampFitFurDogs.Application.Tests.Customers.CreateCustomer;
+
+public class CreateCustomerHandlerTests
+{
+    private readonly FakeCustomerRepository _repo = new();
+    private readonly FakeUnitOfWork _unitOfWork = new();
+    private readonly CreateCustomerHandler _handler;
+
+    public CreateCustomerHandlerTests()
+    {
+        _handler = new CreateCustomerHandler(_repo, _unitOfWork);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_PersistsCustomerAndReturnsId()
+    {
+        var command = new CreateCustomerCommand(
+            FirstName: "Jane",
+            LastName: "Doe",
+            Email: "jane@example.com",
+            Phone: "555-123-4567",
+            Password: "ValidP@ss1");
+
+        var customerId = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, customerId);
+        Assert.Single(_repo.Customers);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_CommitsUnitOfWork()
+    {
+        var command = new CreateCustomerCommand(
+            FirstName: "Jane",
+            LastName: "Doe",
+            Email: "jane@example.com",
+            Phone: "555-123-4567",
+            Password: "ValidP@ss1");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(_unitOfWork.Committed);
+        Assert.Equal(1, _unitOfWork.CommitCount);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateEmail_ThrowsAndDoesNotCommit()
+    {
+        var command = new CreateCustomerCommand(
+            FirstName: "Jane",
+            LastName: "Doe",
+            Email: "jane@example.com",
+            Phone: "555-123-4567",
+            Password: "ValidP@ss1");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        await Assert.ThrowsAsync<EmailAlreadyExistsException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.Equal(1, _unitOfWork.CommitCount);
+    }
+
+}

--- a/tests/CampFitFurDogs.Application.Tests/DependencyInjection/AutoRegistrationTests.cs
+++ b/tests/CampFitFurDogs.Application.Tests/DependencyInjection/AutoRegistrationTests.cs
@@ -6,7 +6,8 @@ using CampFitFurDogs.Application.DependencyInjection;
 using CampFitFurDogs.Application.Abstractions;
 using CampFitFurDogs.Application.Abstractions.Dogs.RegisterDog;
 using CampFitFurDogs.Application.Dogs.RegisterDog;
-using CampFitFurDogs.Domain.Dogs; // needed for IDogRepository
+using CampFitFurDogs.Domain.Customers;
+using CampFitFurDogs.Domain.Dogs;
 using CampFitFurDogs.Application.Tests.Fakes;
 
 namespace CampFitFurDogs.Application.Tests.DependencyInjection;
@@ -19,8 +20,10 @@ public partial class AutoRegistrationTests
         // Arrange
         var services = new ServiceCollection();
 
-        // Stub repository so handler can be constructed
+        // Stub dependencies so handlers can be constructed
         services.AddSingleton<IDogRepository, FakeDogRepository>();
+        services.AddSingleton<ICustomerRepository, FakeCustomerRepository>();
+        services.AddSingleton<IUnitOfWork, FakeUnitOfWork>();
 
         // Act
         services.AddApplicationServices();
@@ -41,6 +44,8 @@ public partial class AutoRegistrationTests
 
         // Provide required fakes so handlers/validators can be constructed
         services.AddSingleton<IDogRepository, FakeDogRepository>();
+        services.AddSingleton<ICustomerRepository, FakeCustomerRepository>();
+        services.AddSingleton<IUnitOfWork, FakeUnitOfWork>();
 
         // Act
         services.AddApplicationServices();
@@ -52,5 +57,4 @@ public partial class AutoRegistrationTests
         validator.Should().NotBeNull();
         validator.Should().BeOfType<RegisterDogCommandValidator>();
     }
-
 }

--- a/tests/CampFitFurDogs.Application.Tests/Dogs/RegisterDog/RegisterDogHandlerTests.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Dogs/RegisterDog/RegisterDogHandlerTests.cs
@@ -8,11 +8,12 @@ namespace CampFitFurDogs.Application.Tests.Dogs.RegisterDog;
 public class RegisterDogHandlerTests
 {
     private readonly FakeDogRepository _repo = new();
+    private readonly FakeUnitOfWork _unitOfWork = new();
     private readonly RegisterDogHandler _handler;
 
     public RegisterDogHandlerTests()
     {
-        _handler = new RegisterDogHandler(_repo);
+        _handler = new RegisterDogHandler(_repo, _unitOfWork);
     }
 
     [Fact]
@@ -52,4 +53,38 @@ public class RegisterDogHandlerTests
 
         Assert.Empty(_repo.Dogs);
     }
+
+    [Fact]
+    public async Task Handle_ValidCommand_CommitsUnitOfWork()
+    {
+        var command = new RegisterDogCommand(
+            OwnerId: Guid.NewGuid(),
+            Name: "Biscuit",
+            Breed: "Golden Retriever",
+            DateOfBirth: new DateOnly(2022, 6, 15),
+            Sex: "Female");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(_unitOfWork.Committed);
+        Assert.Equal(1, _unitOfWork.CommitCount);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidSex_ThrowsAndDoesNotCommit()
+    {
+        var command = new RegisterDogCommand(
+            OwnerId: Guid.NewGuid(),
+            Name: "Biscuit",
+            Breed: "Poodle",
+            DateOfBirth: new DateOnly(2023, 1, 1),
+            Sex: "Unknown");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.False(_unitOfWork.Committed);
+        Assert.Equal(0, _unitOfWork.CommitCount);
+    }
+
 }

--- a/tests/CampFitFurDogs.Application.Tests/Fakes/FakeCustomerRepository.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Fakes/FakeCustomerRepository.cs
@@ -1,0 +1,19 @@
+using CampFitFurDogs.Domain.Customers;
+
+namespace CampFitFurDogs.Application.Tests.Fakes;
+
+public class FakeCustomerRepository : ICustomerRepository
+{
+    public List<Customer> Customers { get; } = [];
+
+    public Task<bool> EmailExistsAsync(Email email, CancellationToken ct)
+    {
+        return Task.FromResult(Customers.Any(c => c.Email == email));
+    }
+
+    public Task AddAsync(Customer customer, CancellationToken ct)
+    {
+        Customers.Add(customer);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/CampFitFurDogs.Application.Tests/Fakes/FakeUnitOfWork.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Fakes/FakeUnitOfWork.cs
@@ -1,0 +1,16 @@
+using CampFitFurDogs.Application.Abstractions;
+
+namespace CampFitFurDogs.Application.Tests.Fakes;
+
+public class FakeUnitOfWork : IUnitOfWork
+{
+    public bool Committed { get; private set; }
+    public int CommitCount { get; private set; }
+
+    public Task<int> CommitAsync(CancellationToken ct = default)
+    {
+        Committed = true;
+        CommitCount++;
+        return Task.FromResult(1);
+    }
+}

--- a/tests/CampFitFurDogs.Infrastructure.Tests/Dogs/DogRepositoryTests.cs
+++ b/tests/CampFitFurDogs.Infrastructure.Tests/Dogs/DogRepositoryTests.cs
@@ -32,6 +32,7 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
                     System.Text.Encoding.UTF8.GetBytes("SuperSecure123!"))));
 
         await repo.AddAsync(customer, CancellationToken.None);
+        await ctx.SaveChangesAsync();
         return customer.Id;
     }
 
@@ -51,6 +52,7 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
             Sex.Female);
 
         await repo.AddAsync(dog, CancellationToken.None);
+        await ctx.SaveChangesAsync();
 
         await using var readCtx = _fixture.CreateContext();
         var all = await readCtx.Set<Dog>().AsNoTracking().ToListAsync();
@@ -78,7 +80,9 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
             new DateOnly(2023, 1, 1),
             Sex.Male);
 
-        var act = () => repo.AddAsync(dog, CancellationToken.None);
+        await repo.AddAsync(dog, CancellationToken.None);
+
+        var act = () => ctx.SaveChangesAsync();
 
         await act.Should().ThrowAsync<DbUpdateException>();
     }
@@ -107,6 +111,7 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
 
         await repo.AddAsync(dog1, CancellationToken.None);
         await repo.AddAsync(dog2, CancellationToken.None);
+        await ctx.SaveChangesAsync();
 
         await using var readCtx = _fixture.CreateContext();
         var allDogs = await readCtx.Set<Dog>().AsNoTracking().ToListAsync();
@@ -131,6 +136,7 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
             Sex.Female);
 
         await writeRepo.AddAsync(dog, CancellationToken.None);
+        await writeCtx.SaveChangesAsync();
 
         await using var readCtx = _fixture.CreateContext();
         var readRepo = new DogRepository(readCtx);
@@ -156,5 +162,4 @@ public class DogRepositoryTests : IClassFixture<PostgresFixture>
 
         result.Should().BeNull();
     }
-
 }


### PR DESCRIPTION
## Summary

Introduces the Unit of Work pattern (`IUnitOfWork` / `EfUnitOfWork`) so that `SaveChangesAsync` is called once per command — by the handler, not by individual repositories. Repositories become pure collection abstractions with no persistence side-effects.

Closes #155

## Changes

### Application.Abstractions
- Added `IUnitOfWork` interface with `CommitAsync(CancellationToken)`

### Application — Handlers
- `CreateCustomerHandler` — accepts `IUnitOfWork`, calls `CommitAsync` after `AddAsync`
- `RegisterDogHandler` — accepts `IUnitOfWork`, calls `CommitAsync` after `AddAsync`

### Infrastructure
- Added `EfUnitOfWork` — delegates to `AppDbContext.SaveChangesAsync`
- `CustomerRepository` — removed `SaveChangesAsync`; fixed `EmailExistsAsync` to compare `Email.Value` (avoids EF owned-type traversal error)
- `DogRepository` — removed `SaveChangesAsync`; fixed `GetByIdAsync` `FindAsync` key array
- `DependencyInjection` — explicit `IUnitOfWork` → `EfUnitOfWork` registration (Scrutor won't match it)

### Tests
- Added `FakeUnitOfWork` and `FakeCustomerRepository` test fakes
- `CreateCustomerHandlerTests` — 4 tests (persist, commit, duplicate-email-no-commit, invalid-email-no-commit)
- `RegisterDogHandlerTests` — 4 tests (persist, commit, invalid-sex-no-commit, commit-count)
- `AutoRegistrationTests` — updated to register `IUnitOfWork` and `ICustomerRepository` fakes
- `DogRepositoryTests` — added explicit `SaveChangesAsync` calls (repos no longer persist)

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed