### PR TITLE
US-107 — EF Entity Auto-Discovery

### DIFF
--- a/product/stories/infra/US-106-add-only-slice-architecture.md
+++ b/product/stories/infra/US-106-add-only-slice-architecture.md
@@ -1,0 +1,132 @@
+# US-106 — Add-Only Slice Architecture
+
+## Intent
+
+As a **developer**, I want introducing a new vertical slice to require only adding new files — never modifying existing ones — so that slices are fully isolated, merge conflicts are eliminated, and the Open-Closed Principle is enforced at the architecture level.
+
+## Value
+
+- **Zero modification points** — new slices never touch shared files.
+- **No merge conflicts** — parallel slice work cannot collide.
+- **Faster onboarding** — "drop files in the right folders" is the entire mental model.
+- **Architectural proof** — if a slice requires editing a shared file, the architecture has a gap.
+
+## Problem
+
+Today, adding a new slice (e.g., GetCustomerProfile) requires modifying **4 existing files**:
+
+| Modified File | Root Cause |
+|---------------|-----------|
+| `ICustomerRepository.cs` | Shared repository interface grows with every new read path |
+| `CustomerRepository.cs` | Implementation follows the interface |
+| `FakeCustomerRepository.cs` | Test fake follows the interface |
+| `CustomerEndpoints.cs` | Central route file grows with every new endpoint |
+
+Two root causes produce all four modification points.
+
+## Solution
+
+### Part A: Auto-Discovered Endpoints (ADR-0013)
+
+Each endpoint self-registers its own route via a marker interface:
+
+```csharp
+// SharedKernel or Abstractions
+public interface IEndpoint
+{
+    void Map(IEndpointRouteBuilder app);
+}
+```
+
+A one-time `DiscoverEndpoints()` extension in Program.cs scans the assembly for `IEndpoint` implementations and calls `Map()` on each. Same Scrutor-style pattern already trusted for handlers.
+
+**Result:** New endpoints are add-only. No more editing `CustomerEndpoints.cs` or `DogEndpoints.cs`.
+
+### Part B: Query-Side Readers (ADR-0014)
+
+Queries define their own data access contract inside the slice folder, not on the shared aggregate repository:
+
+```
+Application/Customers/GetCustomerProfile/
+├── GetCustomerProfileQueryHandler.cs
+├── ICustomerProfileReader.cs          ← slice-scoped read contract
+
+Infrastructure/Customers/GetCustomerProfile/
+├── CustomerProfileReader.cs           ← slice-scoped implementation
+```
+
+Scrutor auto-registers `CustomerProfileReader` → `ICustomerProfileReader` by naming convention. Repositories stay focused on writes (`AddAsync`, `UpdateAsync`, `GetByIdAsync` for command-side rehydration).
+
+**Result:** New query slices never touch `ICustomerRepository`, `CustomerRepository`, or `FakeCustomerRepository`.
+
+### Part C: Retrofit Existing Query Slices
+
+Move the read path from `IDogRepository.GetByIdAsync` into a `IDogProfileReader` inside the ViewDogProfile slice. This validates the pattern and removes the precedent of queries using aggregate repositories.
+
+## File Inventory — Before vs After
+
+### Before (GetCustomerProfile)
+
+| Type | Count |
+|------|-------|
+| New files | 6 |
+| Modified files | 4 |
+| **Total touch points** | **10** |
+
+### After (GetCustomerProfile)
+
+| Type | Count |
+|------|-------|
+| New files | 8 |
+| Modified files | 0 |
+| **Total touch points** | **8** |
+
+## Deliverables
+
+- [ ] ADR-0013: Auto-Discovered Endpoints
+- [ ] ADR-0014: Query-Side Reader Pattern
+- [ ] `IEndpoint` interface in SharedKernel or Abstractions
+- [ ] `DiscoverEndpoints()` extension method
+- [ ] Program.cs wired with `app.DiscoverEndpoints()`
+- [ ] Existing endpoints retrofitted to implement `IEndpoint`
+- [ ] `ICustomerProfileReader` / `CustomerProfileReader` example (if GetCustomerProfile slice exists)
+- [ ] `IDogProfileReader` / `DogProfileReader` retrofit for ViewDogProfile
+- [ ] `IDogRepository.GetByIdAsync` removed (read path moved to reader)
+- [ ] `FakeDogRepository.GetByIdAsync` removed
+- [ ] Guardrail test: every `IEndpoint` implementation is discovered
+- [ ] Guardrail test: no `IQueryHandler` depends on an `IRepository` interface
+- [ ] `copilot-instructions.md` updated with add-only slice rules
+- [ ] `folder-structure.md` updated with reader placement convention
+- [ ] `abstractions-contract.md` updated with reader pattern
+- [ ] `di-conventions.md` updated with reader auto-registration
+
+## Acceptance Criteria
+
+- [ ] Adding a new query slice requires 0 modifications to existing files
+- [ ] Adding a new command slice requires 0 modifications to existing files (once the aggregate's write surface is stable)
+- [ ] Adding a new endpoint requires 0 modifications to existing files
+- [ ] All existing endpoints implement `IEndpoint` and self-register
+- [ ] ViewDogProfile uses `IDogProfileReader`, not `IDogRepository`
+- [ ] Scrutor auto-registers all readers by naming convention (no manual DI)
+- [ ] `DiscoverEndpoints()` discovers and maps all `IEndpoint` implementations
+- [ ] Guardrail test fails if a query handler depends on a repository interface
+- [ ] Guardrail test fails if an `IEndpoint` is not discovered
+- [ ] ADR-0013 and ADR-0014 accepted and indexed
+- [ ] All cross-references in developer docs resolve
+- [ ] CI passes
+
+## Emotional Guarantees
+
+- A developer introducing a new slice never worries about breaking existing slices.
+- A developer never has to coordinate with another developer over shared file edits.
+- A developer can look at the folder and know exactly what files to create — nothing else.
+
+## Dependencies
+
+- US-050 (Unit of Work) — completed (Sprint 5)
+- US-051 (CQRS Pipelines) — completed (Sprint 4)
+- US-079 (Convention-Based Auto-Registration) — completed (Scrutor)
+
+## Estimated Effort
+
+~4 hours (2 ADRs + infrastructure code + retrofit + docs)

--- a/product/stories/infra/US-107-ef-entity-auto-discovery.md
+++ b/product/stories/infra/US-107-ef-entity-auto-discovery.md
@@ -1,0 +1,69 @@
+# US-107 — EF Entity Auto-Discovery
+
+## Intent
+
+As a **contributor**, I want new aggregate roots to be discovered by EF Core automatically through their `IEntityTypeConfiguration<T>` — without editing `AppDbContext` — so that scaffolding a new aggregate never requires modifying an existing file.
+
+## Value
+
+- **Last modification point eliminated** — after US-079 (DI auto-registration) and US-106 (add-only slices), this removes the final shared-file edit required when introducing a new aggregate root.
+- **True open-closed at the aggregate level** — scaffolding a new aggregate is purely additive: drop files, run migration, done.
+- **Stable `AppDbContext`** — the class becomes a sealed, zero-touch infrastructure fixture. No merge conflicts, no forgotten registrations.
+- **Consistent convention-over-configuration** — the same assembly-scanning philosophy used for handlers, validators, readers, and endpoints now applies to EF entity registration.
+
+## Problem
+
+Today, adding a new aggregate root requires **two edits** to `AppDbContext.cs`:
+
+| Line added per aggregate | Purpose |
+|--------------------------|---------|
+| `public DbSet<T> Xs => Set<T>();` | Exposes the entity set |
+| `model.ApplyConfiguration(new XConfiguration());` | Registers the entity type configuration |
+
+These are the only remaining modification points after US-079 and US-106 eliminate DI registration and slice-level edits.
+
+## Solution
+
+### Step 1 — Assembly-scanned configuration
+
+Replace the individual `ApplyConfiguration` calls with a single assembly scan:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder model)
+{
+    model.ApplyConfigurationsFromAssembly(
+        typeof(AppDbContext).Assembly);
+}
+```
+
+Every `IEntityTypeConfiguration<T>` in the Infrastructure assembly is discovered automatically — which is already added as a new file per aggregate (`{Name}Configuration.cs`).
+
+### Step 2 — Remove `DbSet<T>` properties
+
+Delete the explicit `DbSet<Customer>` and `DbSet<Dog>` properties. Repositories use `_context.Set<T>()` directly instead of `_context.Customers` / `_context.Dogs`. EF Core resolves the entity through the model regardless of whether a `DbSet` property exists.
+
+### Step 3 — Retrofit existing repositories
+
+Update `DogRepository` and `CustomerRepository` to use `_context.Set<T>()` for all data access. Verify all existing tests pass.
+
+### Step 4 — Guardrail test
+
+Add an architecture guardrail test that asserts `AppDbContext` declares zero `DbSet<T>` properties — any new one is a build-time signal that the convention was bypassed.
+
+## Acceptance Criteria
+
+- [ ] `OnModelCreating` calls `ApplyConfigurationsFromAssembly` — no individual `ApplyConfiguration` calls remain
+- [ ] `AppDbContext` has zero `DbSet<T>` properties
+- [ ] `DogRepository` and `CustomerRepository` use `Set<T>()` for data access
+- [ ] Architecture guardrail test fails if a `DbSet<T>` property is added to `AppDbContext`
+- [ ] `.github/copilot-instructions.md` updated with `Set<T>()` and `ApplyConfigurationsFromAssembly` conventions
+- [ ] `docs/guides/developer/folder-structure.md` updated (if aggregate scaffold section exists)
+- [ ] `CHANGELOG.md` [Unreleased] section updated
+- [ ] All existing tests pass
+- [ ] CI passes
+
+## Emotional Guarantees
+
+- A contributor scaffolding a new aggregate never opens an existing file.
+- A contributor never worries about forgetting to add a `DbSet` or `ApplyConfiguration` call — the configuration file *is* the registration.
+- The scaffold checklist is purely "create files" — no "edit files" step exists.


### PR DESCRIPTION
## Summary

Adds the US-107 story file — eliminates the final two modification points in `AppDbContext.cs` when scaffolding a new aggregate root:

1. Individual `ApplyConfiguration()` calls → `ApplyConfigurationsFromAssembly`
2. Explicit `DbSet<T>` properties → repositories use `Set<T>()` directly

Story file only — no code changes. Implementation follows in a subsequent PR.

Closes #165

## Changes

- Added `product/stories/infra/US-107-ef-entity-auto-discovery.md`

## Merge Checklist
- [ ] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [ ] Docs updated (if applicable)
- [ ] Changelog updated under Unreleased (if user-facing)
- [ ] No secrets or credentials committed