### PR TITLE
US-038 — Confirm Destructive Action shared component

### DIFF
--- a/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/frontend/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+export interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onCancel={(e) => e.preventDefault()}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+    >
+      <h2>{title}</h2>
+      <p>{description}</p>
+      <button onClick={onCancel} autoFocus>
+        {cancelLabel}
+      </button>
+      <button onClick={onConfirm}>{confirmLabel}</button>
+    </dialog>
+  );
+}

--- a/frontend/test/components/shared/ConfirmDialog.test.tsx
+++ b/frontend/test/components/shared/ConfirmDialog.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { ConfirmDialog } from '../../../src/components/shared/ConfirmDialog';
+
+// jsdom does not implement HTMLDialogElement.showModal / .close
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal ??= vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close ??= vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('ConfirmDialog', () => {
+  const baseProps = {
+    isOpen: true,
+    title: 'Remove Buddy?',
+    description:
+      'This will permanently remove Buddy from your account. This cannot be undone.',
+    confirmLabel: 'Remove',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('renders dialog content when open', () => {
+    render(<ConfirmDialog {...baseProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not render dialog content when closed', () => {
+    render(<ConfirmDialog {...baseProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('displays the title describing the action', () => {
+    render(<ConfirmDialog {...baseProps} />);
+    expect(
+      screen.getByRole('heading', { name: 'Remove Buddy?' }),
+    ).toBeInTheDocument();
+  });
+
+  it('displays the description with consequences', () => {
+    render(<ConfirmDialog {...baseProps} />);
+    expect(
+      screen.getByText(/permanently remove Buddy/),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...baseProps} onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...baseProps} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('focuses the cancel button by default, not confirm', () => {
+    render(<ConfirmDialog {...baseProps} />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+
+  it('calls onCancel when Escape is pressed', async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...baseProps} onCancel={onCancel} />);
+    await userEvent.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a shared `ConfirmDialog` component for destructive actions. Built on the native `<dialog>` element with modal behavior, Escape-to-cancel, and focus defaulting to the safe (cancel) button.

Closes #174

## What's Included

- `ConfirmDialog` component at `src/components/shared/ConfirmDialog.tsx`
- Props: `isOpen`, `title`, `description`, `confirmLabel`, `cancelLabel`, `onConfirm`, `onCancel`
- Native `<dialog>` with `showModal()` for modal overlay and focus trapping
- Cancel button receives default focus — destructive action is never the default
- Escape key calls `onCancel` — cancel without consequence
- 8 unit tests covering all acceptance criteria from US-038

## Acceptance Criteria Mapping

| AC | Test |
|----|------|
| Explicit confirmation before execution | `calls onConfirm when confirm button is clicked` |
| Clearly states what will happen | `displays the title describing the action` |
| States what will be lost | `displays the description with consequences` |
| Cancel without consequence | `calls onCancel when cancel button is clicked` |
| Does not default to destructive option | `focuses the cancel button by default, not confirm` |
| Cancel via keyboard | `calls onCancel when Escape is pressed` |

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed