### PR TITLE
US-035 — Portable accessible validation UX

### DIFF
--- a/frontend/src/components/dogs/DogForm.tsx
+++ b/frontend/src/components/dogs/DogForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { FieldError } from '../shared/FieldError';
 import { FormField } from '../shared/FormField';
+import { validateDogForm } from '../../lib/validateDogForm';
 
 export interface DogFormValues {
   name: string;
@@ -45,11 +46,7 @@ export function DogForm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const newErrors: Record<string, string> = {};
-    if (!name.trim()) newErrors.name = "Please enter your dog's name";
-    if (!breed.trim()) newErrors.breed = 'Please enter a breed';
-    if (!dateOfBirth.trim()) newErrors.dateOfBirth = 'Please enter a date of birth';
-    if (!sex) newErrors.sex = 'Please select a sex';
+    const newErrors = validateDogForm({ name, breed, dateOfBirth, sex });
 
     if (Object.keys(newErrors).length > 0) {
       setValidationErrors(newErrors);

--- a/frontend/src/components/dogs/DogForm.tsx
+++ b/frontend/src/components/dogs/DogForm.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { FieldError } from '../shared/FieldError';
 import { FormField } from '../shared/FormField';
-import { validateDogForm } from '../../lib/validateDogForm';
+import { validateDogForm } from '../../lib/dogs/validateDogForm';
 import type { DogFormValues } from '../../types/dog';
 
 export type { DogFormValues };

--- a/frontend/src/components/dogs/DogForm.tsx
+++ b/frontend/src/components/dogs/DogForm.tsx
@@ -3,13 +3,9 @@ import { useState } from 'react';
 import { FieldError } from '../shared/FieldError';
 import { FormField } from '../shared/FormField';
 import { validateDogForm } from '../../lib/validateDogForm';
+import type { DogFormValues } from '../../types/dog';
 
-export interface DogFormValues {
-  name: string;
-  breed: string;
-  dateOfBirth: string;
-  sex: string;
-}
+export type { DogFormValues };
 
 interface DogFormProps {
   title: string;
@@ -35,18 +31,19 @@ export function DogForm({
   errors,
   isSubmitting,
 }: DogFormProps) {
-  const [name, setName] = useState(initialValues.name);
-  const [breed, setBreed] = useState(initialValues.breed);
-  const [dateOfBirth, setDateOfBirth] = useState(initialValues.dateOfBirth);
-  const [sex, setSex] = useState(initialValues.sex);
+  const [values, setValues] = useState<DogFormValues>(initialValues);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
   const displayErrors = { ...validationErrors, ...errors };
 
+  const update = (field: keyof DogFormValues) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setValues((prev) => ({ ...prev, [field]: e.target.value }));
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const newErrors = validateDogForm({ name, breed, dateOfBirth, sex });
+    const newErrors = validateDogForm(values);
 
     if (Object.keys(newErrors).length > 0) {
       setValidationErrors(newErrors);
@@ -54,7 +51,7 @@ export function DogForm({
     }
 
     setValidationErrors({});
-    onSubmit({ name, breed, dateOfBirth, sex });
+    onSubmit(values);
   };
 
   return (
@@ -67,8 +64,8 @@ export function DogForm({
         {(fieldProps) => (
           <input
             type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={update('name')}
             {...fieldProps}
           />
         )}
@@ -78,8 +75,8 @@ export function DogForm({
         {(fieldProps) => (
           <input
             type="text"
-            value={breed}
-            onChange={(e) => setBreed(e.target.value)}
+            value={values.breed}
+            onChange={update('breed')}
             {...fieldProps}
           />
         )}
@@ -89,8 +86,8 @@ export function DogForm({
         {(fieldProps) => (
           <input
             type="text"
-            value={dateOfBirth}
-            onChange={(e) => setDateOfBirth(e.target.value)}
+            value={values.dateOfBirth}
+            onChange={update('dateOfBirth')}
             {...fieldProps}
           />
         )}
@@ -99,8 +96,8 @@ export function DogForm({
       <FormField label="Sex" name="sex" error={displayErrors.sex}>
         {(fieldProps) => (
           <select
-            value={sex}
-            onChange={(e) => setSex(e.target.value)}
+            value={values.sex}
+            onChange={update('sex')}
             {...fieldProps}
           >
             <option value="">Select</option>

--- a/frontend/src/components/dogs/DogForm.tsx
+++ b/frontend/src/components/dogs/DogForm.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { useState } from 'react';
+import { FieldError } from '../shared/FieldError';
+import { FormField } from '../shared/FormField';
 
 export interface DogFormValues {
   name: string;
@@ -44,10 +46,10 @@ export function DogForm({
     e.preventDefault();
 
     const newErrors: Record<string, string> = {};
-    if (!name.trim()) newErrors.name = 'Name is required';
-    if (!breed.trim()) newErrors.breed = 'Breed is required';
-    if (!dateOfBirth.trim()) newErrors.dateOfBirth = 'Date of birth is required';
-    if (!sex) newErrors.sex = 'Sex is required';
+    if (!name.trim()) newErrors.name = "Please enter your dog's name";
+    if (!breed.trim()) newErrors.breed = 'Please enter a breed';
+    if (!dateOfBirth.trim()) newErrors.dateOfBirth = 'Please enter a date of birth';
+    if (!sex) newErrors.sex = 'Please select a sex';
 
     if (Object.keys(newErrors).length > 0) {
       setValidationErrors(newErrors);
@@ -62,35 +64,54 @@ export function DogForm({
     <form onSubmit={handleSubmit}>
       <h1>{title}</h1>
 
-      {displayErrors.form && <p>{displayErrors.form}</p>}
+      <FieldError id="error-form" message={displayErrors.form} />
 
-      <label>
-        Name
-        <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
-      </label>
-      {displayErrors.name && <p>{displayErrors.name}</p>}
+      <FormField label="Name" name="name" error={displayErrors.name}>
+        {(fieldProps) => (
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            {...fieldProps}
+          />
+        )}
+      </FormField>
 
-      <label>
-        Breed
-        <input type="text" value={breed} onChange={(e) => setBreed(e.target.value)} />
-      </label>
-      {displayErrors.breed && <p>{displayErrors.breed}</p>}
+      <FormField label="Breed" name="breed" error={displayErrors.breed}>
+        {(fieldProps) => (
+          <input
+            type="text"
+            value={breed}
+            onChange={(e) => setBreed(e.target.value)}
+            {...fieldProps}
+          />
+        )}
+      </FormField>
 
-      <label>
-        Date of Birth
-        <input type="text" value={dateOfBirth} onChange={(e) => setDateOfBirth(e.target.value)} />
-      </label>
-      {displayErrors.dateOfBirth && <p>{displayErrors.dateOfBirth}</p>}
+      <FormField label="Date of Birth" name="dateOfBirth" error={displayErrors.dateOfBirth}>
+        {(fieldProps) => (
+          <input
+            type="text"
+            value={dateOfBirth}
+            onChange={(e) => setDateOfBirth(e.target.value)}
+            {...fieldProps}
+          />
+        )}
+      </FormField>
 
-      <label>
-        Sex
-        <select value={sex} onChange={(e) => setSex(e.target.value)}>
-          <option value="">Select</option>
-          <option value="Male">Male</option>
-          <option value="Female">Female</option>
-        </select>
-      </label>
-      {displayErrors.sex && <p>{displayErrors.sex}</p>}
+      <FormField label="Sex" name="sex" error={displayErrors.sex}>
+        {(fieldProps) => (
+          <select
+            value={sex}
+            onChange={(e) => setSex(e.target.value)}
+            {...fieldProps}
+          >
+            <option value="">Select</option>
+            <option value="Male">Male</option>
+            <option value="Female">Female</option>
+          </select>
+        )}
+      </FormField>
 
       <button type="submit" disabled={isSubmitting}>{submitLabel}</button>
     </form>

--- a/frontend/src/components/shared/FieldError.tsx
+++ b/frontend/src/components/shared/FieldError.tsx
@@ -1,0 +1,14 @@
+export interface FieldErrorProps {
+  id: string;
+  message: string | undefined;
+}
+
+export function FieldError({ id, message }: FieldErrorProps) {
+  if (!message) return null;
+
+  return (
+    <p id={id} role="alert">
+      {message}
+    </p>
+  );
+}

--- a/frontend/src/components/shared/FormField.tsx
+++ b/frontend/src/components/shared/FormField.tsx
@@ -1,0 +1,32 @@
+import { FieldError } from './FieldError';
+
+export interface FieldProps {
+  'aria-invalid'?: true;
+  'aria-describedby'?: string;
+}
+
+interface FormFieldProps {
+  label: string;
+  name: string;
+  error: string | undefined;
+  children: (fieldProps: FieldProps) => React.ReactNode;
+}
+
+export function FormField({ label, name, error, children }: FormFieldProps) {
+  const errorId = `error-${name}`;
+
+  const fieldProps: FieldProps = {
+    'aria-invalid': error ? true : undefined,
+    'aria-describedby': error ? errorId : undefined,
+  };
+
+  return (
+    <>
+      <label>
+        {label}
+        {children(fieldProps)}
+      </label>
+      <FieldError id={errorId} message={error} />
+    </>
+  );
+}

--- a/frontend/src/lib/dogs/validateDogForm.ts
+++ b/frontend/src/lib/dogs/validateDogForm.ts
@@ -1,4 +1,4 @@
-import type { DogFormValues } from '../types/dog';
+import type { DogFormValues } from '../../types/dog';
 
 export function validateDogForm(values: DogFormValues): Record<string, string> {
   const errors: Record<string, string> = {};

--- a/frontend/src/lib/validateDogForm.ts
+++ b/frontend/src/lib/validateDogForm.ts
@@ -1,0 +1,10 @@
+import type { DogFormValues } from '../components/dogs/DogForm';
+
+export function validateDogForm(values: DogFormValues): Record<string, string> {
+  const errors: Record<string, string> = {};
+  if (!values.name.trim()) errors.name = "Please enter your dog's name";
+  if (!values.breed.trim()) errors.breed = 'Please enter a breed';
+  if (!values.dateOfBirth.trim()) errors.dateOfBirth = 'Please enter a date of birth';
+  if (!values.sex) errors.sex = 'Please select a sex';
+  return errors;
+}

--- a/frontend/src/lib/validateDogForm.ts
+++ b/frontend/src/lib/validateDogForm.ts
@@ -1,4 +1,4 @@
-import type { DogFormValues } from '../components/dogs/DogForm';
+import type { DogFormValues } from '../types/dog';
 
 export function validateDogForm(values: DogFormValues): Record<string, string> {
   const errors: Record<string, string> = {};

--- a/frontend/src/types/dog.ts
+++ b/frontend/src/types/dog.ts
@@ -1,0 +1,6 @@
+export interface DogFormValues {
+  name: string;
+  breed: string;
+  dateOfBirth: string;
+  sex: string;
+}

--- a/frontend/test/components/dogs/DogForm.test.tsx
+++ b/frontend/test/components/dogs/DogForm.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DogForm } from '../../../src/components/dogs/DogForm';
+
+describe('DogForm validation UX (US-035)', () => {
+  it('marks the name input as aria-invalid when it has an error', async () => {
+    const user = userEvent.setup();
+    render(
+      <DogForm title="Register Dog" submitLabel="Register" onSubmit={vi.fn()} />,
+    );
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByLabelText(/name/i)).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  }, 10000);
+
+  it('links the name input to its error via aria-describedby', async () => {
+    const user = userEvent.setup();
+    render(
+      <DogForm title="Register Dog" submitLabel="Register" onSubmit={vi.fn()} />,
+    );
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    const input = screen.getByLabelText(/name/i);
+    const errorId = input.getAttribute('aria-describedby');
+    expect(errorId).toBeTruthy();
+    expect(document.getElementById(errorId!)).toHaveTextContent(/please enter/i);
+  }, 10000);
+
+  it('uses invitational tone for validation messages', async () => {
+    const user = userEvent.setup();
+    render(
+      <DogForm title="Register Dog" submitLabel="Register" onSubmit={vi.fn()} />,
+    );
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText("Please enter your dog's name")).toBeInTheDocument();
+    expect(screen.getByText('Please enter a breed')).toBeInTheDocument();
+    expect(screen.getByText('Please enter a date of birth')).toBeInTheDocument();
+    expect(screen.getByText('Please select a sex')).toBeInTheDocument();
+  }, 10000);
+
+  it('renders field errors with role="alert" for screen readers', async () => {
+    const user = userEvent.setup();
+    render(
+      <DogForm title="Register Dog" submitLabel="Register" onSubmit={vi.fn()} />,
+    );
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts.length).toBeGreaterThanOrEqual(4);
+  }, 10000);
+
+  it('clears aria-invalid when field is corrected and resubmitted', async () => {
+    const user = userEvent.setup();
+    render(
+      <DogForm title="Register Dog" submitLabel="Register" onSubmit={vi.fn()} />,
+    );
+    await user.click(screen.getByRole('button', { name: /register/i }));
+    expect(screen.getByLabelText(/name/i)).toHaveAttribute('aria-invalid', 'true');
+
+    await user.type(screen.getByLabelText(/name/i), 'Buddy');
+    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
+    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
+    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByLabelText(/name/i)).not.toHaveAttribute('aria-invalid');
+  }, 10000);
+
+  it('renders form-level errors with role="alert"', () => {
+    render(
+      <DogForm
+        title="Register Dog"
+        submitLabel="Register"
+        onSubmit={vi.fn()}
+        errors={{ form: 'Something went wrong. Please try again.' }}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Something went wrong. Please try again.',
+    );
+  });
+});

--- a/frontend/test/components/dogs/EditDogProfileForm.test.tsx
+++ b/frontend/test/components/dogs/EditDogProfileForm.test.tsx
@@ -97,7 +97,7 @@ describe('EditDogProfileForm', () => {
         await user.click(screen.getByRole('button', { name: /save/i }));
 
         expect(
-            screen.getByText('Name is required')
+            screen.getByText("Please enter your dog's name")
         ).toBeInTheDocument();
         expect(onSubmit).not.toHaveBeenCalled();
     }, 10000);
@@ -117,7 +117,7 @@ describe('EditDogProfileForm', () => {
         await user.click(screen.getByRole('button', { name: /save/i }));
 
         expect(
-            screen.getByText('Breed is required')
+            screen.getByText('Please enter a breed')
         ).toBeInTheDocument();
         expect(onSubmit).not.toHaveBeenCalled();
     }, 10000);
@@ -137,7 +137,7 @@ describe('EditDogProfileForm', () => {
         await user.click(screen.getByRole('button', { name: /save/i }));
 
         expect(
-            screen.getByText('Date of birth is required')
+            screen.getByText('Please enter a date of birth')
         ).toBeInTheDocument();
         expect(onSubmit).not.toHaveBeenCalled();
     }, 10000);
@@ -157,7 +157,7 @@ describe('EditDogProfileForm', () => {
         await user.click(screen.getByRole('button', { name: /save/i }));
 
         expect(
-            screen.getByText('Sex is required')
+            screen.getByText('Please select a sex')
         ).toBeInTheDocument();
         expect(onSubmit).not.toHaveBeenCalled();
     }, 10000);

--- a/frontend/test/components/dogs/EditDogProfileForm.test.tsx
+++ b/frontend/test/components/dogs/EditDogProfileForm.test.tsx
@@ -3,176 +3,72 @@ import userEvent from '@testing-library/user-event';
 import { EditDogProfileForm } from '@/components/dogs/EditDogProfileForm';
 
 const initialData = {
-    name: 'Buddy',
-    breed: 'Golden Retriever',
-    dateOfBirth: '2023-06-15',
-    sex: 'Male',
+  name: 'Buddy',
+  breed: 'Golden Retriever',
+  dateOfBirth: '2023-06-15',
+  sex: 'Male',
 };
 
 describe('EditDogProfileForm', () => {
-    it('renders the form with all fields and a save button', () => {
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={vi.fn()}
-            />
-        );
+  it('renders the form with all fields and a save button', () => {
+    render(
+      <EditDogProfileForm initialData={initialData} onSubmit={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/breed/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/date of birth/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sex/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
 
-        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/breed/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/date of birth/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/sex/i)).toBeInTheDocument();
-        expect(
-            screen.getByRole('button', { name: /save/i })
-        ).toBeInTheDocument();
+  it('pre-populates fields with initial data', () => {
+    render(
+      <EditDogProfileForm initialData={initialData} onSubmit={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/name/i)).toHaveValue('Buddy');
+    expect(screen.getByLabelText(/breed/i)).toHaveValue('Golden Retriever');
+    expect(screen.getByLabelText(/date of birth/i)).toHaveValue('2023-06-15');
+    expect(screen.getByLabelText(/sex/i)).toHaveValue('Male');
+  });
+
+  it('calls onSubmit with updated form data', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <EditDogProfileForm initialData={initialData} onSubmit={onSubmit} />,
+    );
+
+    await user.clear(screen.getByLabelText(/name/i));
+    await user.type(screen.getByLabelText(/name/i), 'Max');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Max',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
     });
+  }, 10000);
 
-    it('pre-populates fields with initial data', () => {
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={vi.fn()}
-            />
-        );
+  it('renders validation errors passed via errors prop', () => {
+    render(
+      <EditDogProfileForm
+        initialData={initialData}
+        onSubmit={vi.fn()}
+        errors={{ name: 'Name is already taken' }}
+      />,
+    );
+    expect(screen.getByText('Name is already taken')).toBeInTheDocument();
+  });
 
-        expect(screen.getByLabelText(/name/i)).toHaveValue('Buddy');
-        expect(screen.getByLabelText(/breed/i)).toHaveValue(
-            'Golden Retriever'
-        );
-        expect(screen.getByLabelText(/date of birth/i)).toHaveValue(
-            '2023-06-15'
-        );
-        expect(screen.getByLabelText(/sex/i)).toHaveValue('Male');
-    });
-
-    it('calls onSubmit with updated form data', async () => {
-        const onSubmit = vi.fn();
-        const user = userEvent.setup();
-
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={onSubmit}
-            />
-        );
-
-        await user.clear(screen.getByLabelText(/name/i));
-        await user.type(screen.getByLabelText(/name/i), 'Max');
-        await user.click(screen.getByRole('button', { name: /save/i }));
-
-        expect(onSubmit).toHaveBeenCalledWith({
-            name: 'Max',
-            breed: 'Golden Retriever',
-            dateOfBirth: '2023-06-15',
-            sex: 'Male',
-        });
-    }, 10000);
-
-    it('renders validation errors passed via errors prop', () => {
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={vi.fn()}
-                errors={{ name: 'Name is already taken' }}
-            />
-        );
-
-        expect(
-            screen.getByText('Name is already taken')
-        ).toBeInTheDocument();
-    });
-
-    it('shows error when name is cleared and submitted', async () => {
-        const onSubmit = vi.fn();
-        const user = userEvent.setup();
-
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={onSubmit}
-            />
-        );
-
-        await user.clear(screen.getByLabelText(/name/i));
-        await user.click(screen.getByRole('button', { name: /save/i }));
-
-        expect(
-            screen.getByText("Please enter your dog's name")
-        ).toBeInTheDocument();
-        expect(onSubmit).not.toHaveBeenCalled();
-    }, 10000);
-
-    it('shows error when breed is cleared and submitted', async () => {
-        const onSubmit = vi.fn();
-        const user = userEvent.setup();
-
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={onSubmit}
-            />
-        );
-
-        await user.clear(screen.getByLabelText(/breed/i));
-        await user.click(screen.getByRole('button', { name: /save/i }));
-
-        expect(
-            screen.getByText('Please enter a breed')
-        ).toBeInTheDocument();
-        expect(onSubmit).not.toHaveBeenCalled();
-    }, 10000);
-
-    it('shows error when date of birth is cleared and submitted', async () => {
-        const onSubmit = vi.fn();
-        const user = userEvent.setup();
-
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={onSubmit}
-            />
-        );
-
-        await user.clear(screen.getByLabelText(/date of birth/i));
-        await user.click(screen.getByRole('button', { name: /save/i }));
-
-        expect(
-            screen.getByText('Please enter a date of birth')
-        ).toBeInTheDocument();
-        expect(onSubmit).not.toHaveBeenCalled();
-    }, 10000);
-
-    it('shows error when sex is reset to empty and submitted', async () => {
-        const onSubmit = vi.fn();
-        const user = userEvent.setup();
-
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={onSubmit}
-            />
-        );
-
-        await user.selectOptions(screen.getByLabelText(/sex/i), '');
-        await user.click(screen.getByRole('button', { name: /save/i }));
-
-        expect(
-            screen.getByText('Please select a sex')
-        ).toBeInTheDocument();
-        expect(onSubmit).not.toHaveBeenCalled();
-    }, 10000);
-
-    it('disables the save button when isSubmitting is true', () => {
-        render(
-            <EditDogProfileForm
-                initialData={initialData}
-                onSubmit={vi.fn()}
-                isSubmitting
-            />
-        );
-
-        expect(
-            screen.getByRole('button', { name: /save/i })
-        ).toBeDisabled();
-    });
+  it('disables the save button when isSubmitting is true', () => {
+    render(
+      <EditDogProfileForm
+        initialData={initialData}
+        onSubmit={vi.fn()}
+        isSubmitting
+      />,
+    );
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
 });

--- a/frontend/test/components/dogs/RegisterDogForm.test.tsx
+++ b/frontend/test/components/dogs/RegisterDogForm.test.tsx
@@ -53,7 +53,7 @@ describe('RegisterDogForm', () => {
     await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText("Please enter your dog's name")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   }, 10000);
 
@@ -67,7 +67,7 @@ describe('RegisterDogForm', () => {
     await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('Breed is required')).toBeInTheDocument();
+    expect(screen.getByText('Please enter a breed')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   }, 10000);
 
@@ -81,7 +81,7 @@ describe('RegisterDogForm', () => {
     await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('Date of birth is required')).toBeInTheDocument();
+    expect(screen.getByText('Please enter a date of birth')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   }, 10000);
 
@@ -95,7 +95,7 @@ describe('RegisterDogForm', () => {
     await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('Sex is required')).toBeInTheDocument();
+    expect(screen.getByText('Please select a sex')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   }, 10000);
 
@@ -115,7 +115,7 @@ describe('RegisterDogForm', () => {
     render(<RegisterDogForm onSubmit={onSubmit} />);
 
     await user.click(screen.getByRole('button', { name: /register/i }));
-    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText("Please enter your dog's name")).toBeInTheDocument();
 
     await user.type(screen.getByLabelText(/name/i), 'Buddy');
     await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');

--- a/frontend/test/components/dogs/RegisterDogForm.test.tsx
+++ b/frontend/test/components/dogs/RegisterDogForm.test.tsx
@@ -5,7 +5,6 @@ import { RegisterDogForm } from '@/components/dogs/RegisterDogForm';
 describe('RegisterDogForm', () => {
   it('renders the form with all fields and a submit button', () => {
     render(<RegisterDogForm onSubmit={vi.fn()} />);
-
     expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/breed/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/date of birth/i)).toBeInTheDocument();
@@ -37,67 +36,10 @@ describe('RegisterDogForm', () => {
       <RegisterDogForm
         onSubmit={vi.fn()}
         errors={{ name: 'Name is already taken' }}
-      />
+      />,
     );
-
     expect(screen.getByText('Name is already taken')).toBeInTheDocument();
   });
-
-  it('shows error when name is empty', async () => {
-    const onSubmit = vi.fn();
-    const user = userEvent.setup();
-    render(<RegisterDogForm onSubmit={onSubmit} />);
-
-    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
-    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
-    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
-    await user.click(screen.getByRole('button', { name: /register/i }));
-
-    expect(screen.getByText("Please enter your dog's name")).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  }, 10000);
-
-  it('shows error when breed is empty', async () => {
-    const onSubmit = vi.fn();
-    const user = userEvent.setup();
-    render(<RegisterDogForm onSubmit={onSubmit} />);
-
-    await user.type(screen.getByLabelText(/name/i), 'Buddy');
-    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
-    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
-    await user.click(screen.getByRole('button', { name: /register/i }));
-
-    expect(screen.getByText('Please enter a breed')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  }, 10000);
-
-  it('shows error when date of birth is empty', async () => {
-    const onSubmit = vi.fn();
-    const user = userEvent.setup();
-    render(<RegisterDogForm onSubmit={onSubmit} />);
-
-    await user.type(screen.getByLabelText(/name/i), 'Buddy');
-    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
-    await user.selectOptions(screen.getByLabelText(/sex/i), 'Male');
-    await user.click(screen.getByRole('button', { name: /register/i }));
-
-    expect(screen.getByText('Please enter a date of birth')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  }, 10000);
-
-  it('shows error when sex is not selected', async () => {
-    const onSubmit = vi.fn();
-    const user = userEvent.setup();
-    render(<RegisterDogForm onSubmit={onSubmit} />);
-
-    await user.type(screen.getByLabelText(/name/i), 'Buddy');
-    await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');
-    await user.type(screen.getByLabelText(/date of birth/i), '2023-06-15');
-    await user.click(screen.getByRole('button', { name: /register/i }));
-
-    expect(screen.getByText('Please select a sex')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  }, 10000);
 
   it('does not call onSubmit when validation fails', async () => {
     const onSubmit = vi.fn();
@@ -115,7 +57,7 @@ describe('RegisterDogForm', () => {
     render(<RegisterDogForm onSubmit={onSubmit} />);
 
     await user.click(screen.getByRole('button', { name: /register/i }));
-    expect(screen.getByText("Please enter your dog's name")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
 
     await user.type(screen.getByLabelText(/name/i), 'Buddy');
     await user.type(screen.getByLabelText(/breed/i), 'Golden Retriever');

--- a/frontend/test/components/shared/FieldError.test.tsx
+++ b/frontend/test/components/shared/FieldError.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { FieldError } from '../../../src/components/shared/FieldError';
+
+describe('FieldError', () => {
+  it('renders the error message with role="alert"', () => {
+    render(<FieldError id="error-name" message="Please enter your dog's name" />);
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "Please enter your dog's name",
+    );
+  });
+
+  it('renders with the provided id for aria-describedby linkage', () => {
+    render(<FieldError id="error-name" message="Please enter your dog's name" />);
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'error-name');
+  });
+
+  it('does not render when message is undefined', () => {
+    const { container } = render(
+      <FieldError id="error-name" message={undefined} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/test/components/shared/FormField.test.tsx
+++ b/frontend/test/components/shared/FormField.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FormField } from '../../../src/components/shared/FormField';
+
+describe('FormField', () => {
+  it('renders the label text', () => {
+    render(
+      <FormField label="Name" name="name" error={undefined}>
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  });
+
+  it('passes aria-invalid via fieldProps when error exists', () => {
+    render(
+      <FormField label="Name" name="name" error="Please enter your dog's name">
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Name')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when there is no error', () => {
+    render(
+      <FormField label="Name" name="name" error={undefined}>
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Name')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('passes aria-describedby matching the error element id', () => {
+    render(
+      <FormField label="Name" name="name" error="Please enter your dog's name">
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText('Name');
+    const errorId = input.getAttribute('aria-describedby');
+    expect(errorId).toBe('error-name');
+    expect(document.getElementById(errorId!)).toHaveTextContent(
+      "Please enter your dog's name",
+    );
+  });
+
+  it('renders the error with role="alert" when error exists', () => {
+    render(
+      <FormField label="Name" name="name" error="Please enter your dog's name">
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "Please enter your dog's name",
+    );
+  });
+
+  it('does not render an alert when there is no error', () => {
+    render(
+      <FormField label="Name" name="name" error={undefined}>
+        {(fieldProps) => <input {...fieldProps} />}
+      </FormField>,
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('works with select elements', () => {
+    render(
+      <FormField label="Sex" name="sex" error="Please select a sex">
+        {(fieldProps) => (
+          <select {...fieldProps}>
+            <option value="">Select</option>
+            <option value="Male">Male</option>
+          </select>
+        )}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Sex')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('alert')).toHaveTextContent('Please select a sex');
+  });
+});

--- a/frontend/test/lib/validateDogForm.test.ts
+++ b/frontend/test/lib/validateDogForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateDogForm } from '../../src/lib/validateDogForm';
+import { validateDogForm } from '../../src/lib/dogs/validateDogForm';
 
 describe('validateDogForm', () => {
   it('returns no errors when all fields are valid', () => {

--- a/frontend/test/lib/validateDogForm.test.ts
+++ b/frontend/test/lib/validateDogForm.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { validateDogForm } from '../../src/lib/validateDogForm';
+
+describe('validateDogForm', () => {
+  it('returns no errors when all fields are valid', () => {
+    const result = validateDogForm({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+    expect(result).toEqual({});
+  });
+
+  it('returns an error when name is empty', () => {
+    const result = validateDogForm({
+      name: '',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+    expect(result).toEqual({ name: "Please enter your dog's name" });
+  });
+
+  it('returns an error when name is only whitespace', () => {
+    const result = validateDogForm({
+      name: '   ',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+    expect(result).toEqual({ name: "Please enter your dog's name" });
+  });
+
+  it('returns an error when breed is empty', () => {
+    const result = validateDogForm({
+      name: 'Buddy',
+      breed: '',
+      dateOfBirth: '2023-06-15',
+      sex: 'Male',
+    });
+    expect(result).toEqual({ breed: 'Please enter a breed' });
+  });
+
+  it('returns an error when dateOfBirth is empty', () => {
+    const result = validateDogForm({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '',
+      sex: 'Male',
+    });
+    expect(result).toEqual({ dateOfBirth: 'Please enter a date of birth' });
+  });
+
+  it('returns an error when sex is empty', () => {
+    const result = validateDogForm({
+      name: 'Buddy',
+      breed: 'Golden Retriever',
+      dateOfBirth: '2023-06-15',
+      sex: '',
+    });
+    expect(result).toEqual({ sex: 'Please select a sex' });
+  });
+
+  it('returns errors for all fields when all are empty', () => {
+    const result = validateDogForm({
+      name: '',
+      breed: '',
+      dateOfBirth: '',
+      sex: '',
+    });
+    expect(result).toEqual({
+      name: "Please enter your dog's name",
+      breed: 'Please enter a breed',
+      dateOfBirth: 'Please enter a date of birth',
+      sex: 'Please select a sex',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Makes form validation UX portable, accessible, and consistent. Any form that uses `FormField` gets ARIA attributes, `role="alert"` announcements, and `aria-describedby` linkage automatically — impossible to forget. Validation rules are a pure function with no React dependency.

Closes #176

## Architecture

```
types/dog.ts          ← DogFormValues (shared type, no React)
lib/validateDogForm.ts ← pure validation rules (imports type only)
components/shared/
  FieldError.tsx       ← error text with role="alert" + stable id
  FormField.tsx        ← render-prop: label + input + FieldError + ARIA wiring
components/dogs/
  DogForm.tsx          ← re-exports DogFormValues, uses FormField + validateDogForm
```

Dependency arrows point inward — utilities never import React components.

## What Changed

### New modules

| Module | Location | Purpose |
|--------|----------|---------|
| `DogFormValues` | `src/types/dog.ts` | Shared type — no React dependency |
| `validateDogForm` | `src/lib/validateDogForm.ts` | Pure function — validates values, returns error map |
| `FieldError` | `src/components/shared/FieldError.tsx` | Error text with `role="alert"` and stable `id` |
| `FormField` | `src/components/shared/FormField.tsx` | Render-prop wrapper: label + input + FieldError + ARIA |

### DogForm refactors

- Four `useState` calls consolidated to one `useState<DogFormValues>`
- Inline validation extracted to `validateDogForm`
- Manual ARIA plumbing replaced with `FormField`
- Helper `update(field)` curried onChange factory

```tsx
// Before — manual ARIA, four states, validation inline
<label>Name
  <input aria-invalid={!!errors.name || undefined}
         aria-describedby={errors.name ? 'error-name' : undefined} />
</label>
<FieldError id="error-name" message={errors.name} />

// After — one component, one state, validation extracted
<FormField label="Name" name="name" error={errors.name}>
  {(fieldProps) => <input value={values.name} onChange={update('name')} {...fieldProps} />}
</FormField>
```

### Validation message tone

| Before | After |
|--------|-------|
| Name is required | Please enter your dog's name |
| Breed is required | Please enter a breed |
| Date of birth is required | Please enter a date of birth |
| Sex is required | Please select a sex |

## Test Responsibility

| File | Tests | Owns |
|------|-------|------|
| `validateDogForm.test.ts` | 7 | Validation rules and messages (pure, no rendering) |
| `FieldError.test.tsx` | 3 | Alert role, id linkage, empty state |
| `FormField.test.tsx` | 7 | ARIA plumbing, label, render prop, select support |
| `DogForm.test.tsx` | 6 | Validation UX integration (ARIA on real form, tone, correction) |
| `RegisterDogForm.test.tsx` | 5 | Wrapper: rendering, submit, external errors, gating |
| `EditDogProfileForm.test.tsx` | 5 | Wrapper: pre-population, submit, external errors, isSubmitting |

Wrapper tests no longer duplicate validation assertions — those belong to `validateDogForm.test.ts` and `DogForm.test.tsx`.

## Acceptance Criteria Mapping

| AC | Implementation |
|----|----------------|
| Invalid input identified clearly and specifically | `FormField` wires `aria-invalid` + `aria-describedby` per field |
| Explains what's wrong and how to correct it | Invitational messages guide the fix |
| Tone is neutral and helpful | "Please enter…" / "Please select…" — never accusatory |
| Customer is never surprised | Validation on submit, errors next to fields |
| Consistent across all forms | `FormField` + `validateDogForm` make the pattern portable |

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed