### PR TITLE
US-037 — Shared NotFound + DogNotFound, wired into dog pages

### DIFF
--- a/frontend/src/app/dogs/[id]/edit/page.tsx
+++ b/frontend/src/app/dogs/[id]/edit/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { getDogProfile } from '@/api/dogs/getDogProfile';
 import { toQueryState } from '@/lib/api/queryResult';
+import { DogNotFound } from '@/components/dogs/DogNotFound';
 import { editDogProfile, type EditDogProfileData } from '@/api/dogs/editDogProfile';
 import { EditDogProfileForm } from '@/components/dogs/EditDogProfileForm';
 import { useApiQuery } from '@/lib/hooks/useApiQuery';
@@ -23,7 +24,7 @@ export default function EditDogProfilePage() {
   );
 
   if (state.status === 'loading') return <p>Loading…</p>;
-  if (state.status === 'not-found') return <p>Dog not found.</p>;
+  if (state.status === 'not-found') return <DogNotFound />;
   if (state.status === 'error') return <p>{state.error}</p>;
 
   return (

--- a/frontend/src/app/dogs/[id]/page.tsx
+++ b/frontend/src/app/dogs/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { getDogProfile } from '@/api/dogs/getDogProfile';
 import { toQueryState } from '@/lib/api/queryResult';
+import { DogNotFound } from '@/components/dogs/DogNotFound';
 import { DogProfileCard } from '@/components/dogs/DogProfileCard';
 import DogProfileActionsCard from '@/components/dogs/DogProfileActionsCard';
 import { getDogProfileActions } from '@/lib/dogs/dogProfileActions';
@@ -18,7 +19,7 @@ export default function ViewDogProfilePage() {
   );
 
   if (state.status === 'loading') return <p>Loading…</p>;
-  if (state.status === 'not-found') return <p>Dog not found.</p>;
+  if (state.status === 'not-found') return <DogNotFound />;
   if (state.status === 'error') return <p>{state.error}</p>;
 
   const actions = getDogProfileActions(state.data.id, router.push);

--- a/frontend/src/components/dogs/DogNotFound.tsx
+++ b/frontend/src/components/dogs/DogNotFound.tsx
@@ -1,0 +1,14 @@
+import { NotFound } from '../shared/NotFound';
+
+export function DogNotFound() {
+  return (
+    <NotFound
+      heading="We couldn't find that dog"
+      message="They may have been removed, or the link might be outdated."
+      links={[
+        { label: 'View your dogs', href: '/dogs' },
+        { label: 'Register a new dog', href: '/dogs/register' },
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/shared/NotFound.tsx
+++ b/frontend/src/components/shared/NotFound.tsx
@@ -1,0 +1,28 @@
+interface NotFoundLink {
+  label: string;
+  href: string;
+}
+
+interface NotFoundProps {
+  heading: string;
+  message: string;
+  links?: NotFoundLink[];
+}
+
+export function NotFound({ heading, message, links = [] }: NotFoundProps) {
+  return (
+    <div>
+      <h1>{heading}</h1>
+      <p>{message}</p>
+      {links.length > 0 && (
+        <ul>
+          {links.map((link) => (
+            <li key={link.href}>
+              <a href={link.href}>{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/NotFound.tsx
+++ b/frontend/src/components/shared/NotFound.tsx
@@ -1,4 +1,5 @@
-interface NotFoundLink {
+import Link from 'next/link';
+export interface NotFoundLink {
   label: string;
   href: string;
 }
@@ -18,7 +19,7 @@ export function NotFound({ heading, message, links = [] }: NotFoundProps) {
         <ul>
           {links.map((link) => (
             <li key={link.href}>
-              <a href={link.href}>{link.label}</a>
+              <Link href={link.href}>{link.label}</Link>
             </li>
           ))}
         </ul>

--- a/frontend/test/app/dogs/[id]/edit/page.test.tsx
+++ b/frontend/test/app/dogs/[id]/edit/page.test.tsx
@@ -76,7 +76,7 @@ describe('EditDogProfilePage', () => {
         render(<EditDogProfilePage />);
 
         await waitFor(() => {
-            expect(screen.getByText(/not found/i)).toBeInTheDocument();
+            expect(screen.getByRole('heading', { name: /couldn't find that dog/i })).toBeInTheDocument();
         });
     });
 

--- a/frontend/test/app/dogs/[id]/page.test.tsx
+++ b/frontend/test/app/dogs/[id]/page.test.tsx
@@ -66,7 +66,7 @@ describe('ViewDogProfilePage', () => {
     render(<ViewDogProfilePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /couldn't find that dog/i })).toBeDefined();
+      expect(screen.getByRole('heading', { name: /couldn't find that dog/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/test/app/dogs/[id]/page.test.tsx
+++ b/frontend/test/app/dogs/[id]/page.test.tsx
@@ -66,7 +66,7 @@ describe('ViewDogProfilePage', () => {
     render(<ViewDogProfilePage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Dog not found.')).toBeDefined();
+      expect(screen.getByRole('heading', { name: /couldn't find that dog/i })).toBeDefined();
     });
   });
 });

--- a/frontend/test/components/dogs/DogNotFound.test.tsx
+++ b/frontend/test/components/dogs/DogNotFound.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { DogNotFound } from '@/components/dogs/DogNotFound';
+
+describe('DogNotFound', () => {
+  it('renders a friendly heading about the missing dog', () => {
+    render(<DogNotFound />);
+    expect(
+      screen.getByRole('heading', { name: /couldn't find that dog/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an explanatory message', () => {
+    render(<DogNotFound />);
+    expect(
+      screen.getByText(/may have been removed/i),
+    ).toBeInTheDocument();
+  });
+
+  it('links to the dog list', () => {
+    render(<DogNotFound />);
+    const link = screen.getByRole('link', { name: /view your dogs/i });
+    expect(link).toHaveAttribute('href', '/dogs');
+  });
+
+  it('links to register a new dog', () => {
+    render(<DogNotFound />);
+    const link = screen.getByRole('link', { name: /register a new dog/i });
+    expect(link).toHaveAttribute('href', '/dogs/register');
+  });
+});

--- a/frontend/test/components/shared/NotFound.test.tsx
+++ b/frontend/test/components/shared/NotFound.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { NotFound } from '@/components/shared/NotFound';
+
+describe('NotFound', () => {
+  const defaultProps = {
+    heading: "We couldn't find that dog",
+    message: 'They may have been removed, or the link might be outdated.',
+    links: [
+      { label: 'View your dogs', href: '/dogs' },
+      { label: 'Register a new dog', href: '/dogs/register' },
+    ],
+  };
+
+  it('renders the heading', () => {
+    render(<NotFound {...defaultProps} />);
+    expect(
+      screen.getByRole('heading', { name: /we couldn't find that dog/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the message', () => {
+    render(<NotFound {...defaultProps} />);
+    expect(
+      screen.getByText(/they may have been removed/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders each link with the correct label', () => {
+    render(<NotFound {...defaultProps} />);
+    expect(screen.getByRole('link', { name: /view your dogs/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /register a new dog/i })).toBeInTheDocument();
+  });
+
+  it('renders each link with the correct href', () => {
+    render(<NotFound {...defaultProps} />);
+    expect(screen.getByRole('link', { name: /view your dogs/i })).toHaveAttribute('href', '/dogs');
+    expect(screen.getByRole('link', { name: /register a new dog/i })).toHaveAttribute('href', '/dogs/register');
+  });
+
+  it('renders without links when none are provided', () => {
+    render(<NotFound {...defaultProps} links={[]} />);
+    expect(screen.getByRole('heading', { name: /we couldn't find that dog/i })).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('works for any aggregate, not just dogs', () => {
+    render(
+      <NotFound
+        heading="We couldn't find that booking"
+        message="It may have been cancelled."
+        links={[{ label: 'View bookings', href: '/bookings' }]}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /booking/i })).toBeInTheDocument();
+    expect(screen.getByText(/cancelled/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view bookings/i })).toHaveAttribute('href', '/bookings');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a shared, aggregate-agnostic `NotFound` component and a `DogNotFound` wrapper that owns the dog-specific copy. Both dog pages now render `<DogNotFound />` instead of a bare `<p>Dog not found.</p>`.

Closes #175

## Changes

- Added `NotFound` shared component — heading, message, optional `Link` list; aggregate-agnostic, uses Next.js `Link` for client-side routing; exports `NotFoundLink` type
- Added `DogNotFound` wrapper — dog-specific copy and navigation links (`/dogs`, `/dogs/register`)
- Updated `ViewDogProfilePage` and `EditDogProfilePage` to render `<DogNotFound />` in the not-found branch
- Added 6 tests for `NotFound` and 4 tests for `DogNotFound`
- Updated both page tests to assert heading from `DogNotFound` using `toBeInTheDocument()`

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed