### PR TITLE
US-031: List Dogs by Current User – Frontend Slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - Edit Dog Profile page — owners can update name, breed, date of birth, and sex (US-030)
 - Edit button on View Dog Profile page navigates to the edit form (US-030)
+- Remove Dog — owner can delete a dog from their profile with confirmation (US-087)
+- List Dogs by Current User page — `/dogs` with API client, `ListDogsByCurrentUserCard`, inline actions, and `ActionsCard` (US-031)
 
 ## [Sprint 5] — 2026-04-18
 
@@ -26,7 +27,6 @@ All notable changes to this project will be documented in this file.
 | US-107 | EF Entity Auto-Discovery                   | #165  |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
 - `feature-slice-walkthrough.md` — step-by-step TDD walkthrough for adding command and query slices (US-052)
 - `AppDbContextAutoDiscoveryGuardrailTests` — guardrail ensuring no `DbSet<T>` properties on `AppDbContext` (US-107)
 - `GetDogProfileReaderTests` — 3 integration tests: profile found, not found, wrong owner (US-107)
@@ -91,8 +91,6 @@ All notable changes to this project will be documented in this file.
 | US-103 | Frontend Testing Setup             | #124  |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - `.github/copilot-instructions.md` — living conventions document (standing rules, PR conventions, architecture patterns, tooling, lessons learned)
 - Sprint review closing checklist in `docs/sprint-reviews/_template.md`
 - Conventions maintenance sections in all three contributor guides
@@ -128,8 +126,6 @@ All notable changes to this project will be documented in this file.
 | US-046 | Scrum Master Workflow Guide  | #100  |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - `POST /api/customers` — create customer account (US-027)
 - `POST /api/dogs` — register a dog under a customer (US-028)
 - `GET /api/dogs/{id}` — view dog profile with ownership guard (US-029)
@@ -170,8 +166,6 @@ All notable changes to this project will be documented in this file.
 | US-026 | Declarative Infra Dependencies | #56 |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - ADR-0008: Consistent Editor Experience
 - ADR-0009: Story Naming Convention
 - ADR-0010: Retire Planning YAML Infrastructure
@@ -224,8 +218,6 @@ All notable changes to this project will be documented in this file.
 | US-019 | API DDD Layer Wiring | #20 |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - ADR-0003: Developer Experience Toolchain
 - ADR-0004: Docker Compose for Infrastructure Definitions
 - ADR-0005: Makefile for Standardized Developer Commands
@@ -250,8 +242,6 @@ All notable changes to this project will be documented in this file.
 | US-015 | CI Baseline Build and Test | #8 |
 
 ### Added
-- Shared `NotFound` component and `DogNotFound` wrapper — friendly not-found experience with navigation links on dog pages (US-037)
-
 - Repository initialization
 - ADR-0001: Use Lightweight ADRs
 - ADR-0002: DDD Layered Architecture

--- a/frontend/src/api/dogs/listDogs.ts
+++ b/frontend/src/api/dogs/listDogs.ts
@@ -1,0 +1,26 @@
+import { createApiClient } from '@/lib/api/client';
+import type { QueryResult } from '@/lib/api/queryResult';
+
+export interface DogSummary {
+  id: string;
+  name: string;
+  breed: string;
+}
+
+export interface ListDogsResponse {
+  dogs: DogSummary[];
+}
+
+const client = createApiClient();
+
+export async function listDogs(): Promise<QueryResult<ListDogsResponse>> {
+  const result = await client.get<ListDogsResponse>('/dogs');
+  if (result.ok) {
+    return { success: true, data: result.data };
+  }
+  return {
+    success: false,
+    notFound: false,
+    error: result.error.message,
+  };
+}

--- a/frontend/src/api/dogs/listDogsByCurrentUser.ts
+++ b/frontend/src/api/dogs/listDogsByCurrentUser.ts
@@ -1,20 +1,20 @@
 import { createApiClient } from '@/lib/api/client';
 import type { QueryResult } from '@/lib/api/queryResult';
 
-export interface DogSummary {
+interface DogListItem {
   id: string;
   name: string;
   breed: string;
 }
 
-export interface ListDogsResponse {
-  dogs: DogSummary[];
+export interface ListDogsByCurrentUserResponse {
+  dogs: DogListItem[];
 }
 
 const client = createApiClient();
 
-export async function listDogs(): Promise<QueryResult<ListDogsResponse>> {
-  const result = await client.get<ListDogsResponse>('/dogs');
+export async function listDogsByCurrentUser(): Promise<QueryResult<ListDogsByCurrentUserResponse>> {
+  const result = await client.get<ListDogsByCurrentUserResponse>('/dogs');
   if (result.ok) {
     return { success: true, data: result.data };
   }

--- a/frontend/src/app/dogs/page.tsx
+++ b/frontend/src/app/dogs/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useApiQuery } from '@/lib/hooks/useApiQuery';
+import { listDogs, type ListDogsResponse } from '@/api/dogs/listDogs';
+import { toQueryState } from '@/lib/api/queryResult';
+import Link from 'next/link';
+
+export default function DogsPage() {
+  const state = useApiQuery<ListDogsResponse>(
+    async () => {
+      const result = await listDogs();
+      return toQueryState(result);
+    },
+    []
+  );
+
+  if (state.status === 'loading') return <p>Loading…</p>;
+  if (state.status === 'error') return <p role="alert">{state.error}</p>;
+
+  const { dogs } = state.data;
+
+  return (
+    <div>
+      <h1>My Dogs</h1>
+      {dogs.length === 0 ? (
+        <p>No dogs registered yet.</p>
+      ) : (
+        <ul>
+          {dogs.map((dog) => (
+            <li key={dog.id}>
+              <Link href={`/dogs/${dog.id}`}>
+                {dog.name} — {dog.breed}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/dogs/page.tsx
+++ b/frontend/src/app/dogs/page.tsx
@@ -11,9 +11,11 @@ import { Action } from '@/lib/action';
 
 export default function DogsPage() {
   const router = useRouter();
+
   const actions: Action[] = [
     { label: 'Register', onClick: () => router.push('/dogs/register') },
   ];
+
   const state = useApiQuery<ListDogsByCurrentUserResponse>(
     async () => {
       const result = await listDogsByCurrentUser();

--- a/frontend/src/app/dogs/page.tsx
+++ b/frontend/src/app/dogs/page.tsx
@@ -1,14 +1,22 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useApiQuery } from '@/lib/hooks/useApiQuery';
-import { listDogs, type ListDogsResponse } from '@/api/dogs/listDogs';
+import { listDogsByCurrentUser } from '@/api/dogs/listDogsByCurrentUser';
 import { toQueryState } from '@/lib/api/queryResult';
-import Link from 'next/link';
+import type { ListDogsByCurrentUserResponse } from '@/api/dogs/listDogsByCurrentUser';
+import { ListDogsByCurrentUserCard } from '@/components/dogs/ListDogsByCurrentUserCard';
+import { ActionsCard } from '@/lib/components/ActionsCard';
+import { Action } from '@/lib/action';
 
 export default function DogsPage() {
-  const state = useApiQuery<ListDogsResponse>(
+  const router = useRouter();
+  const actions: Action[] = [
+    { label: 'Register', onClick: () => router.push('/dogs/register') },
+  ];
+  const state = useApiQuery<ListDogsByCurrentUserResponse>(
     async () => {
-      const result = await listDogs();
+      const result = await listDogsByCurrentUser();
       return toQueryState(result);
     },
     []
@@ -16,25 +24,12 @@ export default function DogsPage() {
 
   if (state.status === 'loading') return <p>Loading…</p>;
   if (state.status === 'error') return <p role="alert">{state.error}</p>;
-
-  const { dogs } = state.data;
+  if (state.status === 'not-found') return <p>Not found.</p>;
 
   return (
-    <div>
-      <h1>My Dogs</h1>
-      {dogs.length === 0 ? (
-        <p>No dogs registered yet.</p>
-      ) : (
-        <ul>
-          {dogs.map((dog) => (
-            <li key={dog.id}>
-              <Link href={`/dogs/${dog.id}`}>
-                {dog.name} — {dog.breed}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <>
+      <ListDogsByCurrentUserCard dogs={state.data.dogs} />
+      <ActionsCard actions={actions} />
+    </>
   );
 }

--- a/frontend/src/components/dogs/ListDogsByCurrentUserCard.tsx
+++ b/frontend/src/components/dogs/ListDogsByCurrentUserCard.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+interface DogItem {
+  id: string;
+  name: string;
+  breed: string;
+}
+
+interface ListDogsByCurrentUserCardProps {
+  dogs: DogItem[];
+}
+
+export function ListDogsByCurrentUserCard({ dogs }: ListDogsByCurrentUserCardProps) {
+  return (
+    <div>
+      <h1>My Dogs</h1>
+      {dogs.length === 0 ? (
+        <p>No dogs registered yet.</p>
+      ) : (
+        <ul>
+          {dogs.map((dog) => (
+            <li key={dog.id}>
+              <Link href={`/dogs/${dog.id}`}>
+                {dog.name} — {dog.breed}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/test/api/dogs/listDogs.test.ts
+++ b/frontend/test/api/dogs/listDogs.test.ts
@@ -1,0 +1,43 @@
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  createApiClient: () => ({ get: mockGet }),
+}));
+
+import { listDogs } from '@/api/dogs/listDogs';
+
+describe('listDogs', () => {
+  afterEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('calls GET /dogs and returns dog summaries on success', async () => {
+    const dogs = [
+      { id: 'id-1', name: 'Biscuit', breed: 'Golden Retriever' },
+      { id: 'id-2', name: 'Maple', breed: 'Beagle' },
+    ];
+    mockGet.mockResolvedValue({ ok: true, data: { dogs } });
+
+    const result = await listDogs();
+
+    expect(mockGet).toHaveBeenCalledWith('/dogs');
+    expect(result).toEqual({ success: true, data: { dogs } });
+  });
+
+  it('returns error on failure', async () => {
+    mockGet.mockResolvedValue({
+      ok: false,
+      error: { type: 'http', status: 500, message: 'Server error' },
+    });
+
+    const result = await listDogs();
+
+    expect(result).toEqual({
+      success: false,
+      notFound: false,
+      error: 'Server error',
+    });
+  });
+});

--- a/frontend/test/api/dogs/listDogsByCurrentUser.test.ts
+++ b/frontend/test/api/dogs/listDogsByCurrentUser.test.ts
@@ -6,9 +6,9 @@ vi.mock('@/lib/api/client', () => ({
   createApiClient: () => ({ get: mockGet }),
 }));
 
-import { listDogs } from '@/api/dogs/listDogs';
+import { listDogsByCurrentUser } from '@/api/dogs/listDogsByCurrentUser';
 
-describe('listDogs', () => {
+describe('listDogsByCurrentUser', () => {
   afterEach(() => {
     mockGet.mockReset();
   });
@@ -20,7 +20,7 @@ describe('listDogs', () => {
     ];
     mockGet.mockResolvedValue({ ok: true, data: { dogs } });
 
-    const result = await listDogs();
+    const result = await listDogsByCurrentUser();
 
     expect(mockGet).toHaveBeenCalledWith('/dogs');
     expect(result).toEqual({ success: true, data: { dogs } });
@@ -32,7 +32,7 @@ describe('listDogs', () => {
       error: { type: 'http', status: 500, message: 'Server error' },
     });
 
-    const result = await listDogs();
+    const result = await listDogsByCurrentUser();
 
     expect(result).toEqual({
       success: false,

--- a/frontend/test/app/dogs/page.test.tsx
+++ b/frontend/test/app/dogs/page.test.tsx
@@ -1,32 +1,36 @@
 import { render, screen } from '@testing-library/react';
 
-const { mockListDogs } = vi.hoisted(() => ({
-  mockListDogs: vi.fn(),
+const { mockListDogsByCurrentUser } = vi.hoisted(() => ({
+  mockListDogsByCurrentUser: vi.fn(),
 }));
 
-vi.mock('@/api/dogs/listDogs', () => ({
-  listDogs: mockListDogs,
+vi.mock('@/api/dogs/listDogsByCurrentUser', () => ({
+  listDogsByCurrentUser: mockListDogsByCurrentUser,
 }));
 
 vi.mock('next/link', () => ({
   default: (props: any) => <a href={props.href}>{props.children}</a>,
 }));
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 import DogsPage from '@/app/dogs/page';
 
 describe('DogsPage', () => {
   afterEach(() => {
-    mockListDogs.mockReset();
+    mockListDogsByCurrentUser.mockReset();
   });
 
   it('shows loading state initially', () => {
-    mockListDogs.mockReturnValue(new Promise(() => {}));
+    mockListDogsByCurrentUser.mockReturnValue(new Promise(() => { }));
     render(<DogsPage />);
-    expect(screen.getByText('Loading\u2026')).toBeInTheDocument();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
   });
 
   it('renders list of dogs on success', async () => {
-    mockListDogs.mockResolvedValue({
+    mockListDogsByCurrentUser.mockResolvedValue({
       success: true,
       data: {
         dogs: [
@@ -43,7 +47,7 @@ describe('DogsPage', () => {
   });
 
   it('shows empty state when no dogs registered', async () => {
-    mockListDogs.mockResolvedValue({
+    mockListDogsByCurrentUser.mockResolvedValue({
       success: true,
       data: { dogs: [] },
     });
@@ -56,7 +60,7 @@ describe('DogsPage', () => {
   });
 
   it('shows error message on failure', async () => {
-    mockListDogs.mockResolvedValue({
+    mockListDogsByCurrentUser.mockResolvedValue({
       success: false,
       notFound: false,
       error: 'Something went wrong',

--- a/frontend/test/app/dogs/page.test.tsx
+++ b/frontend/test/app/dogs/page.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+
+const { mockListDogs } = vi.hoisted(() => ({
+  mockListDogs: vi.fn(),
+}));
+
+vi.mock('@/api/dogs/listDogs', () => ({
+  listDogs: mockListDogs,
+}));
+
+vi.mock('next/link', () => ({
+  default: (props: any) => <a href={props.href}>{props.children}</a>,
+}));
+
+import DogsPage from '@/app/dogs/page';
+
+describe('DogsPage', () => {
+  afterEach(() => {
+    mockListDogs.mockReset();
+  });
+
+  it('shows loading state initially', () => {
+    mockListDogs.mockReturnValue(new Promise(() => {}));
+    render(<DogsPage />);
+    expect(screen.getByText('Loading\u2026')).toBeInTheDocument();
+  });
+
+  it('renders list of dogs on success', async () => {
+    mockListDogs.mockResolvedValue({
+      success: true,
+      data: {
+        dogs: [
+          { id: '1', name: 'Biscuit', breed: 'Golden Retriever' },
+          { id: '2', name: 'Maple', breed: 'Beagle' },
+        ],
+      },
+    });
+
+    render(<DogsPage />);
+
+    expect(await screen.findByText(/Biscuit/)).toBeInTheDocument();
+    expect(screen.getByText(/Maple/)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no dogs registered', async () => {
+    mockListDogs.mockResolvedValue({
+      success: true,
+      data: { dogs: [] },
+    });
+
+    render(<DogsPage />);
+
+    expect(
+      await screen.findByText('No dogs registered yet.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows error message on failure', async () => {
+    mockListDogs.mockResolvedValue({
+      success: false,
+      notFound: false,
+      error: 'Something went wrong',
+    });
+
+    render(<DogsPage />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Something went wrong'
+    );
+  });
+});

--- a/frontend/test/app/dogs/page.test.tsx
+++ b/frontend/test/app/dogs/page.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@/api/dogs/listDogsByCurrentUser', () => ({
 }));
 
 vi.mock('next/link', () => ({
-  default: (props: any) => <a href={props.href}>{props.children}</a>,
+  default: (props: { href: string; children: React.ReactNode }) => <a href={props.href}>{props.children}</a>,
 }));
 
 vi.mock('next/navigation', () => ({

--- a/frontend/test/components/dogs/ListDogsByCurrentUserCard.test.tsx
+++ b/frontend/test/components/dogs/ListDogsByCurrentUserCard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { ListDogsByCurrentUserCard } from '@/components/dogs/ListDogsByCurrentUserCard';
+
+vi.mock('next/link', () => ({
+  default: (props: any) => <a href={props.href}>{props.children}</a>,
+}));
+
+describe('ListDogsByCurrentUserCard', () => {
+  it('renders each dog as a link with name and breed', () => {
+    const dogs = [
+      { id: '1', name: 'Biscuit', breed: 'Golden Retriever' },
+      { id: '2', name: 'Maple', breed: 'Beagle' },
+    ];
+
+    render(<ListDogsByCurrentUserCard dogs={dogs} />);
+
+    expect(screen.getByRole('heading', { name: 'My Dogs' })).toBeInTheDocument();
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/dogs/1');
+    expect(links[0]).toHaveTextContent(/Biscuit/);
+    expect(links[0]).toHaveTextContent(/Golden Retriever/);
+    expect(links[1]).toHaveAttribute('href', '/dogs/2');
+    expect(links[1]).toHaveTextContent(/Maple/);
+    expect(links[1]).toHaveTextContent(/Beagle/);
+  });
+
+  it('shows empty state when no dogs registered', () => {
+    render(<ListDogsByCurrentUserCard dogs={[]} />);
+
+    expect(screen.getByText('No dogs registered yet.')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/frontend/test/components/dogs/ListDogsByCurrentUserCard.test.tsx
+++ b/frontend/test/components/dogs/ListDogsByCurrentUserCard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { ListDogsByCurrentUserCard } from '@/components/dogs/ListDogsByCurrentUserCard';
 
 vi.mock('next/link', () => ({
-  default: (props: any) => <a href={props.href}>{props.children}</a>,
+  default: (props: { href: string; children: React.ReactNode }) => <a href={props.href}>{props.children}</a>,
 }));
 
 describe('ListDogsByCurrentUserCard', () => {

--- a/src/CampFitFurDogs.Api/Dogs/ListDogsByCurrentUserEndpoint.cs
+++ b/src/CampFitFurDogs.Api/Dogs/ListDogsByCurrentUserEndpoint.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Builder;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+using SharedKernel.Abstractions;
+using SharedKernel.Api;
+
+namespace CampFitFurDogs.Api.Dogs;
+
+public class ListDogsByCurrentUserEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/dogs", async (
+            ICurrentUserService currentUser,
+            IQueryDispatcher dispatcher) =>
+        {
+            var query = new ListDogsByOwnerQuery(currentUser.CurrentUserId);
+            var result = await dispatcher.DispatchAsync(query, CancellationToken.None);
+            return Results.Ok(result);
+        });
+    }
+}

--- a/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/IListDogsByOwnerReader.cs
+++ b/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/IListDogsByOwnerReader.cs
@@ -1,0 +1,7 @@
+namespace CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+
+public interface IListDogsByOwnerReader
+{
+    Task<ListDogsByOwnerResponse> ListDogsByOwnerAsync(
+        Guid ownerId, CancellationToken ct);
+}

--- a/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/ListDogsByOwnerQuery.cs
+++ b/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/ListDogsByOwnerQuery.cs
@@ -1,0 +1,5 @@
+using SharedKernel.Abstractions;
+
+namespace CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+
+public record ListDogsByOwnerQuery(Guid OwnerId) : IQuery<ListDogsByOwnerResponse>;

--- a/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/ListDogsByOwnerResponse.cs
+++ b/src/CampFitFurDogs.Application/Abstractions/Dogs/ListDogsByOwner/ListDogsByOwnerResponse.cs
@@ -1,0 +1,5 @@
+namespace CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+
+public record DogSummary(Guid Id, string Name, string Breed);
+
+public record ListDogsByOwnerResponse(IReadOnlyList<DogSummary> Dogs);

--- a/src/CampFitFurDogs.Application/Dogs/ListDogsByOwner/ListDogsByOwnerHandler.cs
+++ b/src/CampFitFurDogs.Application/Dogs/ListDogsByOwner/ListDogsByOwnerHandler.cs
@@ -1,0 +1,12 @@
+using SharedKernel.Abstractions;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+
+namespace CampFitFurDogs.Application.Dogs.ListDogsByOwner;
+
+public sealed class ListDogsByOwnerHandler(IListDogsByOwnerReader reader)
+    : IQueryHandler<ListDogsByOwnerQuery, ListDogsByOwnerResponse>
+{
+    public async Task<ListDogsByOwnerResponse> Handle(
+        ListDogsByOwnerQuery query, CancellationToken ct)
+        => await reader.ListDogsByOwnerAsync(query.OwnerId, ct);
+}

--- a/src/CampFitFurDogs.Application/Dogs/ListDogsByOwner/ListDogsByOwnerQueryValidator.cs
+++ b/src/CampFitFurDogs.Application/Dogs/ListDogsByOwner/ListDogsByOwnerQueryValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using SharedKernel.Abstractions;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+
+namespace CampFitFurDogs.Application.Dogs.ListDogsByOwner;
+
+public class ListDogsByOwnerQueryValidator : AbstractValidator<ListDogsByOwnerQuery>
+{
+    public ListDogsByOwnerQueryValidator(ICurrentUserService currentUserService)
+    {
+        RuleFor(x => x.OwnerId).NotEmpty();
+        RuleFor(x => x.OwnerId).Equal(currentUserService.CurrentUserId);
+    }
+}

--- a/src/CampFitFurDogs.Infrastructure/Dogs/ListDogsByOwnerReader.cs
+++ b/src/CampFitFurDogs.Infrastructure/Dogs/ListDogsByOwnerReader.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Domain.Customers;
+using CampFitFurDogs.Domain.Dogs;
+using CampFitFurDogs.Infrastructure.Data;
+
+namespace CampFitFurDogs.Infrastructure.Dogs;
+
+public sealed class ListDogsByOwnerReader(AppDbContext db) : IListDogsByOwnerReader
+{
+    public async Task<ListDogsByOwnerResponse> ListDogsByOwnerAsync(
+        Guid ownerId, CancellationToken ct)
+    {
+        var dogs = await db.Set<Dog>()
+            .Where(d => d.OwnerId == CustomerId.From(ownerId))
+            .Select(d => new DogSummary(d.Id.Value, d.Name.Value, d.Breed.Value))
+            .ToListAsync(ct);
+
+        return new ListDogsByOwnerResponse(dogs);
+    }
+}

--- a/tests/CampFitFurDogs.Api.Tests/ApiTestHelpers.cs
+++ b/tests/CampFitFurDogs.Api.Tests/ApiTestHelpers.cs
@@ -36,16 +36,18 @@ public static class ApiTestHelpers
     }
 
     public static async Task<Guid> RegisterDogAsync(
-        HttpClient client, TestCurrentUser testUserService, Guid ownerId)
+        HttpClient client, TestCurrentUser testUserService, Guid ownerId,
+        string name = "Biscuit", string breed = "Golden Retriever",
+        string dateOfBirth = "2022-06-15", string sex = "Female")
     {
         testUserService.CurrentUserId = ownerId;
 
         var request = new
         {
-            Name = "Biscuit",
-            Breed = "Golden Retriever",
-            DateOfBirth = "2022-06-15",
-            Sex = "Female"
+            Name = name,
+            Breed = breed,
+            DateOfBirth = dateOfBirth,
+            Sex = sex
         };
 
         var response = await client.PostAsJsonAsync("/api/dogs", request);

--- a/tests/CampFitFurDogs.Api.Tests/Dogs/ListDogsByCurrentUserEndpointTests.cs
+++ b/tests/CampFitFurDogs.Api.Tests/Dogs/ListDogsByCurrentUserEndpointTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using CampFitFurDogs.Api.Tests.Fixtures;
+
+using static CampFitFurDogs.Api.Tests.ApiTestHelpers;
+
+namespace CampFitFurDogs.Api.Tests.Dogs;
+
+public class ListDogsByCurrentUserEndpointTests : ApiTestBase
+{
+    private readonly HttpClient _client;
+    private readonly TestCurrentUser _testUserService;
+
+    public ListDogsByCurrentUserEndpointTests(
+        CampFitFurDogsApiFactory factory, PostgresFixture fixture)
+        : base(factory, fixture)
+    {
+        _client = Factory.CreateClient();
+        _testUserService = Factory.TestUser;
+    }
+
+    private sealed record DogSummaryDto(Guid Id, string Name, string Breed);
+    private sealed record ListDogsResponseDto(List<DogSummaryDto> Dogs);
+
+    [Fact]
+    public async Task ListDogs_OwnerHasMultipleDogs_Returns200WithAll()
+    {
+        var ownerId = await CreateAndSetOwnerAsync(_client, _testUserService);
+        var dog1Id = await RegisterDogAsync(
+            _client, _testUserService, ownerId,
+            "Biscuit", "Golden Retriever");
+        var dog2Id = await RegisterDogAsync(
+            _client, _testUserService, ownerId,
+            "Maple", "Beagle");
+
+        var response = await _client.GetAsync("/api/dogs");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<ListDogsResponseDto>();
+        body.Should().NotBeNull();
+        body!.Dogs.Should().HaveCount(2);
+        body.Dogs.Should().Contain(d =>
+            d.Id == dog1Id && d.Name == "Biscuit" && d.Breed == "Golden Retriever");
+        body.Dogs.Should().Contain(d =>
+            d.Id == dog2Id && d.Name == "Maple" && d.Breed == "Beagle");
+    }
+
+    [Fact]
+    public async Task ListDogs_OwnerHasNoDogs_Returns200WithEmptyList()
+    {
+        var ownerId = await CreateAndSetOwnerAsync(_client, _testUserService);
+
+        var response = await _client.GetAsync("/api/dogs");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<ListDogsResponseDto>();
+        body.Should().NotBeNull();
+        body!.Dogs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListDogs_OnlyReturnsDogsForCurrentUser()
+    {
+        var ownerA = await CreateAndSetOwnerAsync(_client, _testUserService);
+        await RegisterDogAsync(
+            _client, _testUserService, ownerA,
+            "Biscuit", "Golden Retriever");
+
+        var ownerB = await CreateAndSetOwnerAsync(_client, _testUserService);
+        await RegisterDogAsync(
+            _client, _testUserService, ownerB,
+            "Maple", "Beagle");
+
+        // Switch back to ownerA
+        _testUserService.CurrentUserId = ownerA;
+
+        var response = await _client.GetAsync("/api/dogs");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<ListDogsResponseDto>();
+        body.Should().NotBeNull();
+        body!.Dogs.Should().HaveCount(1);
+        body.Dogs[0].Name.Should().Be("Biscuit");
+    }
+
+    [Fact]
+    public async Task ListDogs_MissingCustomerId_Returns400()
+    {
+        _testUserService.CurrentUserId = Guid.Empty;
+
+        var response = await _client.GetAsync("/api/dogs");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/CampFitFurDogs.Application.Tests/Dogs/ListDogsByOwner/ListDogsByOwnerHandlerTests.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Dogs/ListDogsByOwner/ListDogsByOwnerHandlerTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Application.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Application.Tests.Fakes;
+using CampFitFurDogs.Domain.Customers;
+using CampFitFurDogs.Domain.Dogs;
+
+namespace CampFitFurDogs.Application.Tests.Dogs.ListDogsByOwner;
+
+public class ListDogsByOwnerHandlerTests
+{
+    private readonly FakeListDogsByOwnerReader _reader = new();
+    private readonly ListDogsByOwnerHandler _handler;
+
+    public ListDogsByOwnerHandlerTests()
+    {
+        _handler = new ListDogsByOwnerHandler(_reader);
+    }
+
+    [Fact]
+    public async Task Handle_OwnerHasMultipleDogs_ReturnsAllDogs()
+    {
+        var ownerId = CustomerId.From(Guid.NewGuid());
+
+        var dog1 = Dog.Create(
+            ownerId,
+            DogName.Create("Biscuit"),
+            Breed.Create("Golden Retriever"),
+            new DateOnly(2022, 6, 15),
+            Sex.Female);
+
+        var dog2 = Dog.Create(
+            ownerId,
+            DogName.Create("Maple"),
+            Breed.Create("Beagle"),
+            new DateOnly(2023, 3, 10),
+            Sex.Male);
+
+        _reader.Add(dog1);
+        _reader.Add(dog2);
+
+        var query = new ListDogsByOwnerQuery(ownerId.Value);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Dogs.Should().HaveCount(2);
+        result.Dogs.Should().Contain(d => d.Name == "Biscuit" && d.Breed == "Golden Retriever");
+        result.Dogs.Should().Contain(d => d.Name == "Maple" && d.Breed == "Beagle");
+    }
+
+    [Fact]
+    public async Task Handle_OwnerHasNoDogs_ReturnsEmptyList()
+    {
+        var query = new ListDogsByOwnerQuery(Guid.NewGuid());
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Dogs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_OnlyReturnsDogsBelongingToOwner()
+    {
+        var ownerA = CustomerId.From(Guid.NewGuid());
+        var ownerB = CustomerId.From(Guid.NewGuid());
+
+        var dogA = Dog.Create(
+            ownerA,
+            DogName.Create("Biscuit"),
+            Breed.Create("Golden Retriever"),
+            new DateOnly(2022, 6, 15),
+            Sex.Female);
+
+        var dogB = Dog.Create(
+            ownerB,
+            DogName.Create("Maple"),
+            Breed.Create("Beagle"),
+            new DateOnly(2023, 3, 10),
+            Sex.Male);
+
+        _reader.Add(dogA);
+        _reader.Add(dogB);
+
+        var query = new ListDogsByOwnerQuery(ownerA.Value);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Dogs.Should().HaveCount(1);
+        result.Dogs[0].Name.Should().Be("Biscuit");
+    }
+}

--- a/tests/CampFitFurDogs.Application.Tests/Dogs/ListDogsByOwner/ListDogsByOwnerQueryValidatorTests.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Dogs/ListDogsByOwner/ListDogsByOwnerQueryValidatorTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Application.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Application.Tests.Fakes;
+
+namespace CampFitFurDogs.Application.Tests.Dogs.ListDogsByOwner;
+
+public class ListDogsByOwnerQueryValidatorTests
+{
+    [Fact]
+    public async Task Validate_OwnerIdMatchesCurrentUser_IsValid()
+    {
+        var userId = Guid.NewGuid();
+        var currentUser = new FakeCurrentUserService(userId);
+        var validator = new ListDogsByOwnerQueryValidator(currentUser);
+
+        var query = new ListDogsByOwnerQuery(userId);
+        var result = await validator.ValidateAsync(query);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_OwnerIdDoesNotMatchCurrentUser_IsInvalid()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid());
+        var validator = new ListDogsByOwnerQueryValidator(currentUser);
+
+        var query = new ListDogsByOwnerQuery(Guid.NewGuid());
+        var result = await validator.ValidateAsync(query);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_OwnerIdIsEmpty_IsInvalid()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.Empty);
+        var validator = new ListDogsByOwnerQueryValidator(currentUser);
+
+        var query = new ListDogsByOwnerQuery(Guid.Empty);
+        var result = await validator.ValidateAsync(query);
+
+        result.IsValid.Should().BeFalse();
+    }
+}

--- a/tests/CampFitFurDogs.Application.Tests/Fakes/FakeCurrentUserService.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Fakes/FakeCurrentUserService.cs
@@ -1,0 +1,8 @@
+using SharedKernel.Abstractions;
+
+namespace CampFitFurDogs.Application.Tests.Fakes;
+
+public class FakeCurrentUserService(Guid currentUserId) : ICurrentUserService
+{
+    public Guid CurrentUserId { get; } = currentUserId;
+}

--- a/tests/CampFitFurDogs.Application.Tests/Fakes/FakeListDogsByOwnerReader.cs
+++ b/tests/CampFitFurDogs.Application.Tests/Fakes/FakeListDogsByOwnerReader.cs
@@ -1,0 +1,22 @@
+using CampFitFurDogs.Application.Abstractions.Dogs.ListDogsByOwner;
+using CampFitFurDogs.Domain.Dogs;
+
+namespace CampFitFurDogs.Application.Tests.Fakes;
+
+public class FakeListDogsByOwnerReader : IListDogsByOwnerReader
+{
+    private readonly List<Dog> _dogs = [];
+
+    public void Add(Dog dog) => _dogs.Add(dog);
+
+    public Task<ListDogsByOwnerResponse> ListDogsByOwnerAsync(
+        Guid ownerId, CancellationToken ct)
+    {
+        var summaries = _dogs
+            .Where(d => d.OwnerId.Value == ownerId)
+            .Select(d => new DogSummary(d.Id.Value, d.Name.Value, d.Breed.Value))
+            .ToList();
+
+        return Task.FromResult(new ListDogsByOwnerResponse(summaries));
+    }
+}

--- a/tests/CampFitFurDogs.Infrastructure.Tests/Dogs/ListDogsByOwnerReaderTests.cs
+++ b/tests/CampFitFurDogs.Infrastructure.Tests/Dogs/ListDogsByOwnerReaderTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using CampFitFurDogs.Domain.Customers;
+using CampFitFurDogs.Domain.Dogs;
+using CampFitFurDogs.Infrastructure.Customers;
+using CampFitFurDogs.Infrastructure.Data;
+using CampFitFurDogs.Infrastructure.Dogs;
+
+namespace CampFitFurDogs.Infrastructure.Tests.Dogs;
+
+public class ListDogsByOwnerReaderTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public ListDogsByOwnerReaderTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private async Task<CustomerId> SeedCustomerAsync(AppDbContext ctx, string uniqueTag)
+    {
+        var customer = Customer.Create(
+            "Frank",
+            "Hughes",
+            Email.From($"{uniqueTag}@example.com"),
+            PhoneNumber.From("555-9876"),
+            PasswordHash.From(
+                Convert.ToBase64String(
+                    System.Text.Encoding.UTF8.GetBytes("TestPass123!"))));
+
+        await new CustomerRepository(ctx).AddAsync(customer, CancellationToken.None);
+        return customer.Id;
+    }
+
+    private async Task<Dog> SeedDogAsync(
+        AppDbContext ctx, CustomerId ownerId, string name, string breed)
+    {
+        var dog = Dog.Create(
+            ownerId,
+            DogName.Create(name),
+            Breed.Create(breed),
+            new DateOnly(2022, 6, 15),
+            Sex.Female);
+
+        await new DogRepository(ctx).AddAsync(dog, CancellationToken.None);
+        return dog;
+    }
+
+    [Fact]
+    public async Task ListDogsByOwnerAsync_OwnerHasMultipleDogs_ReturnsAll()
+    {
+        await using var seedCtx = _fixture.CreateContext();
+        var ownerId = await SeedCustomerAsync(seedCtx, $"list-multi-{Guid.NewGuid()}");
+        await SeedDogAsync(seedCtx, ownerId, "Biscuit", "Golden Retriever");
+        await SeedDogAsync(seedCtx, ownerId, "Maple", "Beagle");
+        await seedCtx.SaveChangesAsync();
+
+        await using var readCtx = _fixture.CreateContext();
+        var reader = new ListDogsByOwnerReader(readCtx);
+
+        var result = await reader.ListDogsByOwnerAsync(
+            ownerId.Value, CancellationToken.None);
+
+        result.Dogs.Should().HaveCount(2);
+        result.Dogs.Should().Contain(d => d.Name == "Biscuit" && d.Breed == "Golden Retriever");
+        result.Dogs.Should().Contain(d => d.Name == "Maple" && d.Breed == "Beagle");
+    }
+
+    [Fact]
+    public async Task ListDogsByOwnerAsync_OwnerHasNoDogs_ReturnsEmptyList()
+    {
+        await using var ctx = _fixture.CreateContext();
+        var reader = new ListDogsByOwnerReader(ctx);
+
+        var result = await reader.ListDogsByOwnerAsync(
+            Guid.NewGuid(), CancellationToken.None);
+
+        result.Dogs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListDogsByOwnerAsync_OnlyReturnsDogsBelongingToOwner()
+    {
+        await using var seedCtx = _fixture.CreateContext();
+        var ownerA = await SeedCustomerAsync(seedCtx, $"list-a-{Guid.NewGuid()}");
+        var ownerB = await SeedCustomerAsync(seedCtx, $"list-b-{Guid.NewGuid()}");
+        await SeedDogAsync(seedCtx, ownerA, "Biscuit", "Golden Retriever");
+        await SeedDogAsync(seedCtx, ownerB, "Rex", "German Shepherd");
+        await seedCtx.SaveChangesAsync();
+
+        await using var readCtx = _fixture.CreateContext();
+        var reader = new ListDogsByOwnerReader(readCtx);
+
+        var result = await reader.ListDogsByOwnerAsync(
+            ownerA.Value, CancellationToken.None);
+
+        result.Dogs.Should().HaveCount(1);
+        result.Dogs[0].Name.Should().Be("Biscuit");
+    }
+}
+


### PR DESCRIPTION
## Summary

Implements the frontend vertical slice for **List Dogs by Current User** — API client, presentational card, page orchestrator with inline actions, and full test coverage.

Closes #177

## Changes

- `listDogsByCurrentUser` API client + response type
- `ListDogsByCurrentUserCard` presentational component (heading, dog list, empty state)
- `DogsPage` orchestrator with `useApiQuery`, inline `Action[]`, and `ActionsCard`
- Tests for API client, card (populated + empty), page (loading, success, empty, error)
- Wired `/dogs` route
- CHANGELOG updated for US-031 and US-087

## Merge Checklist

- [x] PR description is complete and linked to an issue
- [x] CI (`Build & Test`) is passing
- [x] Self-review completed
- [x] Docs updated (if applicable)
- [x] Changelog updated under Unreleased (if user-facing)
- [x] No secrets or credentials committed