### PR TITLE
Update Dockerfile to .NET 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ============================
 # BUILD STAGE
 # ============================
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 
 # Copy solution + project files first (cache-friendly)
@@ -14,7 +14,6 @@ COPY src/CampFitFurDogs.Infrastructure/CampFitFurDogs.Infrastructure.csproj src/
 COPY src/SharedKernel/SharedKernel.csproj src/SharedKernel/
 COPY src/SharedKernel.Api/SharedKernel.Api.csproj src/SharedKernel.Api/
 
-# Restore dependencies
 RUN dotnet restore
 
 # Copy the rest of the source
@@ -31,7 +30,7 @@ RUN dotnet publish src/CampFitFurDogs.Api/CampFitFurDogs.Api.csproj \
 # ============================
 # RUNTIME STAGE
 # ============================
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 COPY --from=build /app/publish .


### PR DESCRIPTION
## Summary

This PR updates the backend Dockerfile to use the .NET 10 SDK and ASP.NET runtime images.
The previous Dockerfile referenced .NET 8, which caused Render to pull .NET 8 base images and prevented the API from building correctly.
This change aligns the container build with the project’s target framework (`net10.0`) and ensures correct restore, publish, and runtime behavior.

Closes #<issue-number>

## Changes

- Updated build stage to `mcr.microsoft.com/dotnet/sdk:10.0`
- Updated runtime stage to `mcr.microsoft.com/dotnet/aspnet:10.0`
- Retained existing multi-stage build, ReadyToRun settings, and entrypoint

## Merge Checklist

- [ ] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [ ] Story follows grammar and conventions
- [ ] No internal system concepts exposed
- [ ] Naming and file placement follow conventions