### PR TITLE
Fix Dockerfile Restore Target (API Only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY src/CampFitFurDogs.Infrastructure/CampFitFurDogs.Infrastructure.csproj src/
 COPY src/SharedKernel/SharedKernel.csproj src/SharedKernel/
 COPY src/SharedKernel.Api/SharedKernel.Api.csproj src/SharedKernel.Api/
 
-RUN dotnet restore
+RUN dotnet restore src/CampFitFurDogs.Api/CampFitFurDogs.Api.csproj
 
 # Copy the rest of the source
 COPY . .


### PR DESCRIPTION
## Summary

This PR updates the Dockerfile to restore only the API project instead of the entire solution.
The `.slnx` includes many projects (including tests and infrastructure slices) that are not copied into the container before restore, causing MSB3202 errors.
Restoring only the API project is correct for container builds and aligns with our deployment model.

Closes #<issue-number>

## Changes

- Updated Dockerfile to run:
  `dotnet restore src/CampFitFurDogs.Api/CampFitFurDogs.Api.csproj`
- Avoids restoring test projects and infrastructure slices not needed for deployment
- Unblocks container build and reduces build time

## Merge Checklist

- [ ] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [ ] Story follows grammar and conventions
- [ ] No internal system concepts exposed
- [ ] Naming and file placement follow conventions