### PR TITLE
Bind Kestrel to Render PORT for Deployment

### DIFF
--- a/src/CampFitFurDogs.Api/Program.cs
+++ b/src/CampFitFurDogs.Api/Program.cs
@@ -10,6 +10,9 @@ using SharedKernel.Infrastructure.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+
 // 0. CORS: allow frontend host
 var allowedOrigin = builder.Configuration["Frontend:BaseUrl"];
 


### PR DESCRIPTION
## Summary

Render requires applications to bind to the `$PORT` environment variable and listen on `0.0.0.0`.
The API was previously using default Kestrel bindings (localhost:5000/5001), causing the container to exit immediately during deployment.

This PR updates `Program.cs` to explicitly bind to the Render-provided port, ensuring the API starts correctly in the container runtime.

Closes #<issue-number>

## Changes

- Added explicit Kestrel binding:
  - Reads `PORT` environment variable
  - Falls back to 8080 locally
  - Binds to `http://0.0.0.0:{port}`

## Merge Checklist

- [ ] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [ ] Story follows grammar and conventions
- [ ] No internal system concepts exposed
- [ ] Naming and file placement follow conventions