### PR TITLE
Force Kestrel to Bind to IPv4 Any for Render Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN dotnet publish src/CampFitFurDogs.Api/CampFitFurDogs.Api.csproj \
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
+ENV ASPNETCORE_URLS=http://0.0.0.0:${PORT}
+
 COPY --from=build /app/publish .
 
 ENTRYPOINT ["dotnet", "CampFitFurDogs.Api.dll"]

--- a/src/CampFitFurDogs.Api/Program.cs
+++ b/src/CampFitFurDogs.Api/Program.cs
@@ -11,10 +11,13 @@ using SharedKernel.Infrastructure.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+
 builder.WebHost.ConfigureKestrel(options =>
 {
-    options.ListenAnyIP(int.Parse(port));
+    options.Listen(System.Net.IPAddress.Any, int.Parse(port)); // IPv4 ANY
 });
+
+builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
 
 // 0. CORS: allow frontend host
 var allowedOrigin = builder.Configuration["Frontend:BaseUrl"];


### PR DESCRIPTION
## Summary

Render’s port scanner is IPv4-only.
Kestrel was binding to IPv6 Any (`[::]:{port}`), which works locally but is invisible to Render’s port scan.
This caused repeated deploy failures with “no open ports detected” despite the container being healthy.

This PR updates `Program.cs` to explicitly bind Kestrel to IPv4 Any (`0.0.0.0:{port}`), ensuring Render can detect the open port and complete deployment.

Closes #<issue-number>

## Changes

- Added explicit IPv4 Kestrel binding:
  - Reads `PORT` environment variable
  - Falls back to 8080 locally
  - Uses `IPAddress.Any` to force IPv4 binding

## Merge Checklist

- [ ] PR description is complete and linked to an issue
- [ ] CI (`Build & Test`) is passing
- [ ] Self-review completed
- [ ] Story follows grammar and conventions
- [ ] No internal system concepts exposed
- [ ] Naming and file placement follow conventions